### PR TITLE
fix: resolve secret scanning workflow failures

### DIFF
--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -40,12 +40,10 @@ jobs:
 
       - name: 🔍 GitLeaks Secret Detection
         uses: gitleaks/gitleaks-action@v2
-        with:
-          # Use custom config to exclude test files and documentation
-          config-path: .gitleaks.toml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }} # Only required for Organizations
+          GITLEAKS_CONFIG: .gitleaks.toml
 
   credential-scanning:
     name: 🔑 Credential Pattern Analysis

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -118,14 +118,7 @@ jobs:
         TIMESTAMP=$(cat docs/api/summary.json | jq -r '.lastUpdated')
         
         git add docs/api/
-        git commit -m "docs: auto-update API documentation
-
-📚 Automated documentation update
-🔧 Tools documented: $TOOL_COUNT
-📅 Generated: $TIMESTAMP
-🤖 Updated by GitHub Actions
-
-[skip ci]"
+        git commit -m "docs: auto-update API documentation - Tools: $TOOL_COUNT - Generated: $TIMESTAMP [skip ci]"
 
     - name: 🚀 Push Documentation Changes
       if: steps.changes.outputs.changed == 'true' && github.event_name == 'push'

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -31,7 +31,16 @@ regexes = [
     '''username:password''',
     '''curl -u username:''',
     '''const encryptionKey = "test1234567890"''',
-    '''WORDPRESS_APP_PASSWORD=xxxx\s+xxxx\s+xxxx\s+xxxx\s+xxxx\s+xxxx'''
+    '''WORDPRESS_APP_PASSWORD=xxxx\s+xxxx\s+xxxx\s+xxxx\s+xxxx\s+xxxx''',
+    '''GPG key: `[A-F0-9]{40}`''',
+    '''F41410131B6F78543A3F215943569F605BBEA4DC'''
+]
+
+# Stop words that should not trigger secret detection
+stopwords = [
+    "1234567890abcdef",
+    "test1234567890",
+    "F41410131B6F78543A3F215943569F605BBEA4DC"
 ]
 
 # Specific commits to ignore (if needed)

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -32,8 +32,7 @@ regexes = [
     '''curl -u username:''',
     '''const encryptionKey = "test1234567890"''',
     '''WORDPRESS_APP_PASSWORD=xxxx\s+xxxx\s+xxxx\s+xxxx\s+xxxx\s+xxxx''',
-    '''GPG key: `[A-F0-9]{40}`''',
-    '''F41410131B6F78543A3F215943569F605BBEA4DC'''
+    '''GPG key: [A-F0-9]{40}'''
 ]
 
 # Stop words that should not trigger secret detection


### PR DESCRIPTION
Fixes failing secret scanning workflow by removing invalid config-path parameter and adding proper gitleaks configuration to ignore false positives.

## Summary by Sourcery

Fix secret scanning workflow by updating gitleaks action configuration and enhancing the gitleaks ignore rules.

Bug Fixes:
- Resolve secret scanning failures by replacing the invalid config-path option with the GITLEAKS_CONFIG environment variable

Enhancements:
- Add stopwords and extra regex patterns to .gitleaks.toml to ignore known false positives

CI:
- Update secret-scanning workflow to pass the gitleaks config via environment variable instead of config-path input