### PR TITLE
fix: remove unused Babel dependencies causing CI depcheck failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,8 +159,6 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
-    "@babel/preset-env": "^7.28.3",
-    "@babel/preset-typescript": "^7.27.1",
     "@eslint/js": "^9.32.0",
     "@jest/globals": "^30.0.5",
     "@pact-foundation/pact": "^15.0.1",


### PR DESCRIPTION
## Summary
- Remove unused `@babel/preset-env` and `@babel/preset-typescript` dependencies
- These were flagged as unused by `depcheck` in CI pipeline, causing exit code 255
- Fixes CI/CD pipeline failure while maintaining all functionality

## Changes
- Removed 2 unused devDependencies from package.json
- All tests continue to pass (1,279/1,279 ✅)
- All linting continues to work correctly
- `depcheck` now reports no issues

## Testing
- ✅ `npm run lint` - ESLint still works perfectly
- ✅ `npx depcheck` - No unused dependencies found
- ✅ All 1,279 tests continue to pass locally
- ✅ Build process unaffected

This resolves the CI/CD pipeline failure that was blocking builds after our previous test fixes.

🤖 Generated with [Claude Code](https://claude.ai/code)