### PR TITLE
fix: correct DXT entry point from .cjs to .js (fixes #100)

### DIFF
--- a/dxt/manifest.json
+++ b/dxt/manifest.json
@@ -36,11 +36,11 @@
   ],
   "server": {
     "type": "node",
-    "entry_point": "dist/dxt-entry.cjs",
+    "entry_point": "dist/dxt-entry.js",
     "mcp_config": {
       "command": "node",
       "args": [
-        "${__dirname}/dist/dxt-entry.cjs"
+        "${__dirname}/dist/dxt-entry.js"
       ],
       "env": {
         "WORDPRESS_SITE_URL": "${user_config.wordpress_site_url}",


### PR DESCRIPTION
## 🐛 Bug Fix

This PR fixes issue #100 where the DXT package failed to install on Windows 11 with a "Failed to preview extension" error.

## 🔍 Root Cause
The DXT manifest () was incorrectly referencing `dist/dxt-entry.cjs` as the entry point, but TypeScript compilation produces `dist/dxt-entry.js`. This mismatch caused Claude Desktop to fail when attempting to load the extension.

## ✅ Changes
- Updated `dxt/manifest.json` to use correct entry point: `dist/dxt-entry.js`
- Changed both `entry_point` and `mcp_config.args` references
- Rebuilt and tested the DXT package with corrected configuration

## 🧪 Testing
- ✅ Rebuilt DXT package with `npm run dxt:package:official`
- ✅ Package validates correctly with `dxt pack` command
- ✅ All 1237+ tests passing

## 📦 Impact
- Fixes DXT installation on Windows 11 (and all platforms)
- No changes to npm package or core functionality
- Only affects DXT packaging manifest

Fixes #100