### PR TITLE
fix: detect bin wrapper entry point in isMainModule check

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -140,12 +140,17 @@ async function main() {
   }
 }
 
-// Check if running as main module - handle both direct execution and DXT entry point
+// Check if running as main module - handle direct execution, DXT, and bin wrapper entry points
+const currentFile = fileURLToPath(import.meta.url);
+const callerFile = process.argv[1];
+
 const isMainModule =
-  process.argv[1] === fileURLToPath(import.meta.url) ||
-  process.argv[1]?.endsWith("/index.js") ||
-  process.argv[1]?.endsWith("\\index.js") ||
-  !process.argv[1]; // When run through DXT, process.argv[1] might be undefined
+  callerFile === currentFile ||
+  callerFile?.endsWith("/index.js") ||
+  callerFile?.endsWith("\\index.js") ||
+  callerFile?.endsWith("/mcp-wordpress.js") || // invoked via bin/mcp-wordpress.js wrapper
+  callerFile?.endsWith("\\mcp-wordpress.js") ||
+  !callerFile; // When run through DXT, process.argv[1] might be undefined
 
 if (isMainModule) {
   main();


### PR DESCRIPTION
# Pull Request

## Description

When invoked via bin/mcp-wordpress.js (e.g. through npx or a direct node call), process.argv[1] points to the bin wrapper rather than dist/index.js, causing isMainModule to evaluate as false and main() to never be called. The server would start silently and do nothing.

Add bin wrapper filenames (mcp-wordpress.js) to the isMainModule check so the server starts correctly regardless of how it is invoked.

Also refactor the check to use named variables for clarity.


## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvements
- [ ] 🔒 Security fix

## Testing

### Test Environment

- [x] Local development environment
- [ ] WordPress version: [e.g. 6.4.2]
- [x] Node.js version: v22.22.0
- [ ] Authentication method tested: [e.g. App Passwords, JWT]

### Tests Performed

- [x] Unit tests pass (`npm test`)
- [ ] Health check passes (`npm run health`)
- [x] TypeScript compilation (`npm run build`)
- [x] Linting passes (`npm run lint`)
- [x] Manual testing performed

### Test Cases

Added bin/mcp-wordpress.js in ~/.cursor/mcp.json Cursor IDE config, tested that tools show up instead of waiting for tools and timeout.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

## Summary by Sourcery

Ensure the WordPress MCP server entry point runs correctly regardless of how the CLI is invoked.

Bug Fixes:
- Fix main module detection so the server starts when invoked via the bin/mcp-wordpress.js wrapper as well as direct index.js execution or DXT.

Enhancements:
- Refactor main-module detection logic to use named variables for the current file and caller file for improved clarity.