### PR TITLE
Fix: Add missing 'items' schema to metrics array in wp_performance_history (OpenCode compatibility)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -224,3 +224,4 @@ scripts/mojibake-scan-*.json
 evaluations/results/
 evaluations/reports/
 evaluations/config/existing-sites-eval.yaml
+.history/

--- a/src/tools/performance/PerformanceTools.ts
+++ b/src/tools/performance/PerformanceTools.ts
@@ -144,6 +144,7 @@ export default class PerformanceTools {
           {
             name: "metrics",
             type: "array",
+            items: { type: "string" },
             description:
               "Specific metrics to include (responseTime, cacheHitRate, errorRate, memoryUsage, requestVolume)",
             required: false,


### PR DESCRIPTION
Description of the problem:
Strict MCP clients like OpenCode enforce rigid JSON Schema validation for tool parameters to prevent LLM hallucinations. Currently, the wp_performance_history tool defines the metrics parameter as an array but fails to specify the items type. This causes the client to reject the schema and fail to initialize the tools.

Error encountered:
When trying to list or use the tools in OpenCode, the following fatal validation error is thrown:

"Invalid schema for function 'wp_performance_history': In context=('properties', 'metrics'), array schema missing items"

Proposed solution:
Added the missing items: { type: "string" } property to the metrics parameter definition inside PerformanceTools.js. This makes the JSON Schema valid and fully compatible with strict MCP clients without affecting existing functionality in other clients (like Claude Desktop).

## Summary by Sourcery

Bug Fixes:
- Specify the string item type for the metrics array parameter in the performance tool schema to satisfy strict JSON Schema validation.