### PR TITLE
fix(deps): patch qs CVE-2026-8723 via override to >=6.15.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11959,9 +11959,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "minimatch": "10.2.3",
     "path-to-regexp": ">=8.4.0",
     "postcss": ">=8.5.10",
+    "qs": ">=6.15.2",
     "tar": "7.5.11",
     "underscore": "1.13.8",
     "vite": ">=7.3.2"


### PR DESCRIPTION
## Summary

- Adds `"qs": ">=6.15.2"` to the `overrides` block in `package.json`
- Bumps `qs` from 6.15.0 → 6.15.2 in `package-lock.json`
- Resolves CVE-2026-8723 (medium): `qs.stringify` threw `TypeError` in 6.15.0

## Test plan

- [x] `npm install` resolves `qs` to 6.15.2
- [x] `npm audit --production` reports 0 vulnerabilities
- [x] Full test suite passes (72 tests)
- [x] Pre-commit hooks pass (lint, typecheck, 371 security tests)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

## Summary by Sourcery

Patch the vulnerable qs dependency to a secure version via package overrides.

Bug Fixes:
- Resolve qs-related vulnerability by enforcing qs >= 6.15.2.

Build:
- Add an override in package.json to pin qs to >= 6.15.2 across the dependency tree.

Chores:
- Regenerate lockfile to bump qs to a secure patched version.