### PR TITLE
fix: remove unnecessary pre-fetch GET in handleUpdatePost

### DIFF
--- a/src/tools/posts/PostHandlers.ts
+++ b/src/tools/posts/PostHandlers.ts
@@ -337,9 +337,6 @@ export async function handleUpdatePost(
   try {
     const postId = validateId(params.id, "post ID");
 
-    // Get original post to show what changed
-    const originalPost = await client.getPost(postId);
-
     const { id: _id, ...updateData } = params;
     validatePostParams(updateData, true);
 
@@ -352,20 +349,12 @@ export async function handleUpdatePost(
     response += `**Status**: ${updatedPost.status}\n`;
     response += `**Modified**: ${new Date(updatedPost.modified).toLocaleString()}\n`;
 
-    // Show what changed
+    // Show which fields were updated
     const changes: string[] = [];
-    if (params.title && originalPost.title.rendered !== updatedPost.title.rendered) {
-      changes.push(`Title: "${originalPost.title.rendered}" → "${updatedPost.title.rendered}"`);
-    }
-    if (params.status && originalPost.status !== updatedPost.status) {
-      changes.push(`Status: "${originalPost.status}" → "${updatedPost.status}"`);
-    }
-    if (params.content && originalPost.content?.rendered !== updatedPost.content?.rendered) {
-      changes.push("Content updated");
-    }
-    if (params.excerpt && originalPost.excerpt?.rendered !== updatedPost.excerpt?.rendered) {
-      changes.push("Excerpt updated");
-    }
+    if (params.title) changes.push(`Title: "${updatedPost.title.rendered}"`);
+    if (params.status) changes.push(`Status: "${updatedPost.status}"`);
+    if (params.content) changes.push("Content updated");
+    if (params.excerpt) changes.push("Excerpt updated");
 
     if (changes.length > 0) {
       response += `\n**Changes Made**:\n${changes.map((c) => `- ${c}`).join("\n")}\n`;

--- a/tests/tools/posts.test.js
+++ b/tests/tools/posts.test.js
@@ -322,16 +322,6 @@ describe("PostTools", () => {
 
   describe("handleUpdatePost", () => {
     it("should update a post successfully", async () => {
-      const mockOriginalPost = {
-        id: 1,
-        title: { rendered: "Original Post" },
-        content: { rendered: "Original Content" },
-        status: "draft",
-        author: 1,
-        categories: [],
-        tags: [],
-      };
-
       const mockUpdatedPost = {
         id: 1,
         title: { rendered: "Updated Post" },
@@ -344,8 +334,6 @@ describe("PostTools", () => {
         link: "https://test-site.com/updated-post",
       };
 
-      // First call to getPost for original post, then updatePost
-      mockClient.getPost.mockResolvedValueOnce(mockOriginalPost);
       mockClient.updatePost.mockResolvedValueOnce(mockUpdatedPost);
 
       const updateData = {
@@ -356,7 +344,7 @@ describe("PostTools", () => {
 
       const result = await postTools.handleUpdatePost(mockClient, updateData);
 
-      expect(mockClient.getPost).toHaveBeenCalledWith(1);
+      expect(mockClient.getPost).not.toHaveBeenCalled();
       expect(mockClient.updatePost).toHaveBeenCalledWith({ id: 1, title: "Updated Post", content: "Updated Content" });
       expect(typeof result).toBe("string");
       expect(result).toContain("Post Updated Successfully");
@@ -364,16 +352,6 @@ describe("PostTools", () => {
     });
 
     it("should update a post with content only (no title)", async () => {
-      const mockOriginalPost = {
-        id: 1,
-        title: { rendered: "Original Post" },
-        content: { rendered: "Original Content" },
-        status: "publish",
-        author: 1,
-        categories: [],
-        tags: [],
-      };
-
       const mockUpdatedPost = {
         id: 1,
         title: { rendered: "Original Post" },
@@ -386,7 +364,6 @@ describe("PostTools", () => {
         link: "https://test-site.com/original-post",
       };
 
-      mockClient.getPost.mockResolvedValueOnce(mockOriginalPost);
       mockClient.updatePost.mockResolvedValueOnce(mockUpdatedPost);
 
       const result = await postTools.handleUpdatePost(mockClient, {
@@ -395,8 +372,37 @@ describe("PostTools", () => {
         status: "publish",
       });
 
+      expect(mockClient.getPost).not.toHaveBeenCalled();
       expect(mockClient.updatePost).toHaveBeenCalledWith({ id: 1, content: "New content only", status: "publish" });
       expect(typeof result).toBe("string");
+      expect(result).toContain("Post Updated Successfully");
+    });
+
+    it("should not pre-fetch original post before updating (avoids double HTTP round-trip)", async () => {
+      const mockUpdatedPost = {
+        id: 1,
+        title: { rendered: "Updated Post" },
+        content: { rendered: "Updated Content" },
+        status: "publish",
+        author: 1,
+        categories: [],
+        tags: [],
+        modified: "2024-01-01T12:00:00",
+        link: "https://test-site.com/updated-post",
+      };
+
+      mockClient.updatePost.mockResolvedValueOnce(mockUpdatedPost);
+
+      const result = await postTools.handleUpdatePost(mockClient, {
+        id: 1,
+        title: "Updated Post",
+        content: "Updated Content",
+      });
+
+      // Fix for hang bug: update must make exactly ONE API call (updatePost), not two (getPost + updatePost).
+      // The pre-fetch getPost was unnecessary and caused accumulated timeouts on slow WordPress servers.
+      expect(mockClient.getPost).not.toHaveBeenCalled();
+      expect(mockClient.updatePost).toHaveBeenCalledTimes(1);
       expect(result).toContain("Post Updated Successfully");
     });
 

--- a/tests/tools/posts/PostTools.test.js
+++ b/tests/tools/posts/PostTools.test.js
@@ -359,14 +359,6 @@ describe("PostTools", () => {
 
   describe("handleUpdatePost", () => {
     beforeEach(() => {
-      mockClient.getPost.mockResolvedValue({
-        id: 1,
-        title: { rendered: "Original Post" },
-        content: { rendered: "<p>Original content</p>" },
-        status: "draft",
-        excerpt: { rendered: "Original excerpt" },
-      });
-
       mockClient.updatePost.mockResolvedValue({
         id: 1,
         title: { rendered: "Updated Post" },
@@ -387,7 +379,7 @@ describe("PostTools", () => {
         title: "Updated Post",
       });
 
-      expect(mockClient.getPost).toHaveBeenCalledWith(1);
+      expect(mockClient.getPost).not.toHaveBeenCalled();
       expect(mockClient.updatePost).toHaveBeenCalledWith(
         expect.objectContaining({
           id: 1,
@@ -427,7 +419,7 @@ describe("PostTools", () => {
     });
 
     it("should handle update errors", async () => {
-      mockClient.getPost.mockRejectedValue(new Error("404 Post not found"));
+      mockClient.updatePost.mockRejectedValue(new Error("404 Post not found"));
 
       const result = await postTools.handleUpdatePost(mockClient, {
         id: 999,


### PR DESCRIPTION
## Summary

- Removes the `client.getPost()` pre-fetch call inside `handleUpdatePost` that doubled HTTP round-trips
- On slow WordPress servers this caused retry/rate-limit delays accumulating to ~3-4 minutes total
- Change summary now uses fields from `params` and the `updatedPost` response — no extra request needed

## Test plan

- [x] 1 new regression test asserting `getPost` is never called during `wp_update_post`
- [x] 2 existing tests updated to reflect the corrected single-request behaviour
- [x] Full test suite: 2,577 tests passing across all 4 suites
- [x] TypeScript build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Remove unnecessary pre-fetching in post update handling to avoid extra HTTP calls and slowdowns.

Bug Fixes:
- Eliminate the pre-update getPost request in handleUpdatePost to prevent doubled HTTP round-trips and related timeouts.
- Adjust error handling in handleUpdatePost tests to reflect failures coming from updatePost rather than getPost.

Enhancements:
- Simplify the post update summary to describe updated fields based on request parameters and the update response instead of diffing against a pre-fetched original post.

Tests:
- Update existing handleUpdatePost tests to expect no pre-fetching and a single updatePost call, and add coverage ensuring only one API call is made during updates.