### PR TITLE
chore: upgrade softprops/action-gh-release v2 → v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -298,7 +298,7 @@ jobs:
           node -e "const m = require('./package.json'); if (m.version !== '${{ needs.semantic-release.outputs.new-release-version }}') { console.error('Version mismatch:', m.version, 'vs', '${{ needs.semantic-release.outputs.new-release-version }}'); process.exit(1); } else { console.log('Version verified:', m.version); }"
 
       - name: 📤 Upload DXT Package to Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ needs.semantic-release.outputs.new-release-version }}
           files: mcp-wordpress.dxt


### PR DESCRIPTION
## Summary

- Bumps `softprops/action-gh-release` from `v2` to `v3` in `release.yml`
- v3 runs on Node.js 24, resolving the deprecation warning GitHub Actions will enforce from **June 2, 2026**

## Test plan

- [x] Pre-commit hooks passed (lint, typecheck, security tests)
- [x] Pre-push hooks passed (full build + 2577 tests)
- [ ] Verify DXT upload step succeeds on next release run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Update the release workflow to use softprops/action-gh-release v3 instead of v2 for the DXT package upload step.