### PR TITLE
fix: update Railway banner image to v2 asset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="right">
 <a href="https://railway.com?referralCode=QhjuBc">
-  <img width="160" src="https://raw.githubusercontent.com/docdyhr/.github/main/assets/railway-corner@2x.png" alt="Deploy on Railway — $20 free credits">
+  <img width="160" src="https://raw.githubusercontent.com/docdyhr/.github/main/assets/railway-corner-v2@2x.png" alt="Deploy on Railway — $20 free credits">
 </a>
 </div>
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<div align="right">
+<a href="https://railway.com?referralCode=QhjuBc">
+  <img width="160" src="https://raw.githubusercontent.com/docdyhr/.github/main/assets/railway-corner@2x.png" alt="Deploy on Railway — $20 free credits">
+</a>
+</div>
+
 # 🚀 MCP WordPress Server
 
 <div align="center">
@@ -21,8 +27,6 @@ Manage WordPress sites with natural language through AI tools like Claude Deskto
 
 [![TypeScript](https://img.shields.io/badge/TypeScript-100%25-blue?logo=typescript&logoColor=white)](https://github.com/docdyhr/mcp-wordpress)
 [![CodeQL](https://github.com/docdyhr/mcp-wordpress/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/docdyhr/mcp-wordpress/actions/workflows/codeql-analysis.yml)
-[![Quality Assurance](https://github.com/docdyhr/mcp-wordpress/actions/workflows/quality-assurance.yml/badge.svg)](https://github.com/docdyhr/mcp-wordpress/actions/workflows/quality-assurance.yml)
-[![Security Monitoring](https://github.com/docdyhr/mcp-wordpress/actions/workflows/security-monitoring.yml/badge.svg)](https://github.com/docdyhr/mcp-wordpress/actions/workflows/security-monitoring.yml)
 [![Docker](https://img.shields.io/badge/docker-ready-blue?logo=docker&logoColor=white)](https://hub.docker.com/r/docdyhr/mcp-wordpress)
 [![License](https://img.shields.io/badge/license-MIT-green?logo=opensource&logoColor=white)](https://github.com/docdyhr/mcp-wordpress/blob/main/LICENSE)
 <!-- Badges updated: 2025-12-23 -->
@@ -1175,4 +1179,3 @@ implementation.
 **⭐ Found this helpful? [Give us a star on GitHub!](https://github.com/docdyhr/mcp-wordpress) ⭐**
 
 </div>
-


### PR DESCRIPTION
## Summary

- Updates Railway deploy badge from `railway-corner@2x.png` to `railway-corner-v2@2x.png` in README

## Test plan

- [ ] Verify Railway banner renders correctly on the GitHub README

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update project README branding and badges.

New Features:
- Add a right-aligned Railway deployment banner linking to the project referral page in the README.

Enhancements:
- Remove outdated Quality Assurance and Security Monitoring workflow badges from the README badges section.