### PR TITLE
fix: tighten security overrides for axios and brace-expansion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3051,15 +3051,43 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/b4a": {
@@ -3292,9 +3320,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -128,8 +128,8 @@
         "form-data": "^4.0.3"
       }
     },
-    "axios": ">=1.15.0",
-    "brace-expansion": ">=5.0.5",
+    "axios": ">=1.16.0",
+    "brace-expansion": ">=5.0.6",
     "express-rate-limit": ">=8.5.1",
     "fast-uri": ">=3.1.2",
     "flatted": ">=3.4.2",


### PR DESCRIPTION
## Summary

Tighten two off-by-one override constraints that left vulnerable versions in the tree:

| Package | Old override | Resolved to | New override | Resolves to |
|---|---|---|---|---|
| `axios` | `>=1.15.0` | `1.15.2` ❌ | `>=1.16.0` | `1.16.1` ✅ |
| `brace-expansion` | `>=5.0.5` | `5.0.5` ❌ | `>=5.0.6` | `5.0.6` ✅ |

### CVEs resolved

- **GHSA-pjwm-pj3p-43mv** — axios `shouldBypassProxy` NO_PROXY bypass (high)
- **GHSA-898c-q2cr-xwhg** — axios DoS & header injection via prototype pollution (high)
- **GHSA-35jp-ww65-95wh** — axios MitM via prototype pollution in `config.proxy` (high)
- **GHSA-f886-m6hf-6m8v** — brace-expansion zero-step sequence DoS (moderate)
- **GHSA-jxxr-4gwj-5jf2** — brace-expansion large numeric range DoS (moderate)

### Remaining audit hits (not fixable here)

3 findings in `node_modules/npm/node_modules/...` are npm's own bundled dependencies — they require npm itself to ship a fix and are outside the scope of this project.

## Test plan

- [x] All 2578 tests pass locally
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Raise the minimum overridden versions of axios and brace-expansion in package.json to ensure resolution to non-vulnerable releases.