### PR TITLE
fix(ci): grant pull-requests write permission to claude-code-review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -17,8 +17,8 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:


### PR DESCRIPTION
## Problem

The `claude-code-review` job has been failing on every PR with:

```
App token exchange failed: 401 Unauthorized - User does not have write access on this repository
```

The action uses OIDC to exchange a GitHub token for an app token that can post review comments. The token exchange was failing because the `permissions` block only granted `pull-requests: read`.

## Fix

Changed `pull-requests: read` → `pull-requests: write` and `issues: read` → `issues: write` so the OIDC app token exchange succeeds and the action can post inline review comments.

## Summary by Sourcery

CI:
- Update the claude-code-review workflow permissions from read to write for pull-requests and issues to allow the OIDC app token exchange and comment posting.