### PR TITLE
fix(deps): patch hono moderate vulns and allowlist npm-bundled advisories

### DIFF
--- a/.audit-ci.json
+++ b/.audit-ci.json
@@ -8,6 +8,8 @@
     "GHSA-c2c7-rcm5-vvqj",
     "GHSA-3v7f-55p6-f55p",
     "GHSA-f886-m6hf-6m8v",
+    "GHSA-jxxr-4gwj-5jf2",
+    "GHSA-v2v4-37r5-5v8g",
     "GHSA-xjpj-3mr7-gcpf",
     "GHSA-xhpv-hc6g-r9c6",
     "GHSA-9cx6-37pm-9jff",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6314,9 +6314,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "fast-uri": ">=3.1.2",
     "flatted": ">=3.4.2",
     "follow-redirects": ">=1.15.12",
-    "hono": ">=4.12.16",
+    "hono": ">=4.12.21",
     "minimatch": "10.2.3",
     "path-to-regexp": ">=8.4.0",
     "postcss": ">=8.5.10",


### PR DESCRIPTION
## Summary

- Bumps the `hono` package.json override from `>=4.12.16` → `>=4.12.21`, forcing an upgrade from the vulnerable 4.12.18 to 4.12.25. Resolves 4 moderate CVEs: GHSA-xrhx-7g5j-rcj5, GHSA-3hrh-pfw6-9m5x, GHSA-f577-qrjj-4474, GHSA-2gcr-mfcq-wcc3 (all `hono <=4.12.20`).
- Adds `GHSA-jxxr-4gwj-5jf2` (brace-expansion large numeric range) and `GHSA-v2v4-37r5-5v8g` (ip-address XSS) to the `.audit-ci.json` allowlist. Both are bundled inside npm itself (`node_modules/npm/node_modules/...`) and are not fixable via `package.json` overrides — only an npm engine upgrade can address them.

## Test plan

- [x] `npm install` — hono upgraded 4.12.18 → 4.12.25
- [x] `npx audit-ci --config .audit-ci.json` — passes with 0 unhandled vulnerabilities
- [x] `npm test` — 2578/2578 tests passed across all 4 batches
- [x] Pre-commit and pre-push hooks passed (lint, typecheck, security tests, full build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update dependency policies to address hono security vulnerabilities and adjust audit allowlisting for npm-bundled advisories.

Bug Fixes:
- Raise the minimo version constraint for hono to ensure vulnerable versions are not installed.

CI:
- Extend audit-ci configuration to allowlist npm-bundled security advisories that cannot be fixed via application dependencies.

Chores:
- Regenerate the package-lock.json to reflect updated dependency constraints.