### PR TITLE
fix: resolve project review issues (README version drift, dead code, console patch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Manage WordPress sites with natural language through AI tools like Claude Deskto
 [![Docker](https://img.shields.io/badge/docker-ready-blue?logo=docker&logoColor=white)](https://hub.docker.com/r/docdyhr/mcp-wordpress)
 [![License](https://img.shields.io/badge/license-MIT-green?logo=opensource&logoColor=white)](https://github.com/docdyhr/mcp-wordpress/blob/main/LICENSE)
 <!-- Badges updated: 2025-12-23 -->
-### 🎉 **v2.12.0** - Modular Architecture & Fault Tolerance!
+### 🎉 **v3.3.14** - Production Ready!
 
 </div>
 
@@ -1134,36 +1134,22 @@ Looking for alternatives or complementary tools? Check out these WordPress MCP i
 
 ## 📋 Changelog
 
-### v2.12.0 (December 2024) 🎉
+### v3.3.14 (June 2026)
 
-- **🏗️ Modular Architecture** - Split large files into domain-specific operation modules
-- **🔄 Circuit Breaker Pattern** - Fault tolerance for external API calls with automatic recovery
-- **📊 2200+ Tests** - Comprehensive test suite with operations and performance helper coverage
-- **📚 Deprecation Documentation** - Clear migration timeline for deprecated modules
-- **🔒 Security Improvements** - Updated dependencies and consolidated CI/CD workflows
+- **🔒 Security Updates** - Patch hono moderate vulnerabilities, update allowlisted npm-bundled advisories
+- **🧪 CI** - Smoke-test improvements and Node 24 validation
 
-### v2.5.4+ (August 2024)
+### v3.x Series (2025–2026)
 
-- **🆕 Multi-Site DXT Extension** - New UI toggle for managing multiple WordPress sites in Claude Desktop
-- **🔧 Enhanced Configuration** - Auto-detection of multi-site configuration files
-- **⚡ Performance Improvements** - Optimized caching and request handling
-- **🛡️ Security Updates** - Enhanced input validation and dependency updates
-- **🐛 Bug Fixes** - Resolved hook path issues and improved error handling
-- **📚 Documentation** - Updated setup guides and troubleshooting information
+- **🏗️ Modular Architecture** - Domain-specific operation modules and composition pattern
+- **🔄 Fault Tolerance** - Circuit breaker pattern for external API calls with automatic recovery
+- **📊 2200+ Tests** - Comprehensive test suite across security, cache, server, client, config, utils, tools, and performance
+- **⚡ Caching Layer** - `CachedWordPressClient` with configurable TTL; 50–70% faster repeat requests
+- **🌐 Multi-Site** - Unlimited WordPress sites from one configuration file
+- **🔐 4 Auth Methods** - App Passwords (recommended), JWT, Basic, API Key
+- **🐳 Docker & DXT** - One-click Claude Desktop extension and Docker Hub image
 
-### v2.5.0 (July 2024)
-
-- **🚀 Production Ready** - Comprehensive testing suite with 96%+ coverage
-- **🔒 Security Framework** - Full security validation and penetration testing
-- **📊 Performance Analytics** - Real-time monitoring and optimization tools
-- **🎯 Tool Enhancements** - 59 WordPress management tools across 10 categories
-
-### v2.0.0 (June 2024)
-
-- **🏗️ Architecture Overhaul** - Migrated to modern TypeScript architecture
-- **🌐 Multi-Site Support** - Complete multi-site WordPress management
-- **💾 Intelligent Caching** - 50-70% performance improvement
-- **🔐 Authentication Methods** - Support for 4 authentication types
+For the full history see [CHANGELOG.md](CHANGELOG.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1136,7 +1136,7 @@ Looking for alternatives or complementary tools? Check out these WordPress MCP i
 
 ### v3.3.14 (June 2026)
 
-- **🔒 Security Updates** - Patch hono moderate vulnerabilities, update allowlisted npm-bundled advisories
+- **🔒 Security Updates** - Patch moderate Hono vulnerabilities, update allowlisted npm-bundled advisories
 - **🧪 CI** - Smoke-test improvements and Node 24 validation
 
 ### v3.x Series (2025–2026)

--- a/src/config/ServerConfiguration.ts
+++ b/src/config/ServerConfiguration.ts
@@ -37,12 +37,15 @@ export class ServerConfiguration {
 
     // Load environment variables silently. dotenv v17 logs an injection summary to
     // console.log unless quiet:true is set, which would corrupt MCP stdio JSON-RPC.
-    dotenv.config({
+    const dotenvResult = dotenv.config({
       path: this.envPath,
       debug: false,
       quiet: true,
       override: false,
     });
+    if (dotenvResult.error && ConfigHelpers.shouldDebug()) {
+      this.logger.debug("dotenv: .env file not loaded", { reason: dotenvResult.error.message });
+    }
 
     // Debug output for DXT troubleshooting (reduced in DXT mode)
     if (ConfigHelpers.shouldDebug()) {

--- a/src/config/ServerConfiguration.ts
+++ b/src/config/ServerConfiguration.ts
@@ -35,28 +35,14 @@ export class ServerConfiguration {
     this.rootDir = path.resolve(__dirname, "../..");
     this.envPath = path.resolve(this.rootDir, ".env");
 
-    // Load environment variables (completely silent for MCP compatibility)
-    // Suppress dotenv output that could interfere with JSON-RPC communication
-    // eslint-disable-next-line no-console
-    const originalConsoleLog = console.log;
-    // eslint-disable-next-line no-console
-    const originalConsoleError = console.error;
-    try {
-      // eslint-disable-next-line no-console
-      console.log = () => {};
-      // eslint-disable-next-line no-console
-      console.error = () => {};
-      dotenv.config({
-        path: this.envPath,
-        debug: false,
-        override: false,
-      });
-    } finally {
-      // eslint-disable-next-line no-console
-      console.log = originalConsoleLog;
-      // eslint-disable-next-line no-console
-      console.error = originalConsoleError;
-    }
+    // Load environment variables silently. dotenv v17 logs an injection summary to
+    // console.log unless quiet:true is set, which would corrupt MCP stdio JSON-RPC.
+    dotenv.config({
+      path: this.envPath,
+      debug: false,
+      quiet: true,
+      override: false,
+    });
 
     // Debug output for DXT troubleshooting (reduced in DXT mode)
     if (ConfigHelpers.shouldDebug()) {

--- a/src/server/ToolRegistry.ts
+++ b/src/server/ToolRegistry.ts
@@ -3,7 +3,6 @@ import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { WordPressClient } from "@/client/api.js";
 import { getErrorMessage } from "@/utils/error.js";
 import { EnhancedError, ErrorHandlers } from "@/utils/enhancedError.js";
-import { config } from "@/config/Config.js";
 import * as Tools from "@/tools/index.js";
 import { z } from "zod";
 import type { MCPToolSchema, JSONSchemaProperty } from "@/types/mcp.js";
@@ -132,9 +131,9 @@ export class ToolRegistry {
             };
           }
 
-          // Intelligent site selection for single-site configurations
+          // Auto-select the only site in single-site configurations.
           if (!siteId) {
-            siteId = this.selectBestSite(tool.name, args);
+            siteId = this.selectBestSite();
           }
 
           const client = this.wordpressClients.get(siteId as string);
@@ -363,49 +362,13 @@ export class ToolRegistry {
   }
 
   /**
-   * Intelligent site selection based on context
+   * Return the single configured site ID.
+   * Only called after the multi-site guard (which requires an explicit `site` param),
+   * so this path is only reached in single-site mode.
    */
-  private selectBestSite(toolName: string, args: Record<string, unknown>): string {
-    const availableSites = Array.from(this.wordpressClients.keys());
-
-    // Single site scenario - use it directly
-    if (availableSites.length === 1) {
-      return availableSites[0];
-    }
-
-    // Multiple sites scenario - intelligent selection
-    if (availableSites.length > 1) {
-      // Try to find a site based on context clues
-
-      // 1. Check if there's a 'default' site
-      if (availableSites.includes("default")) {
-        return "default";
-      }
-
-      // 2. Check if there's a 'main' or 'primary' site
-      const primarySites = availableSites.filter((site) =>
-        ["main", "primary", "prod", "production"].includes(site.toLowerCase()),
-      );
-      if (primarySites.length > 0) {
-        return primarySites[0];
-      }
-
-      // 3. For development/test operations, prefer dev sites
-      if (toolName.includes("test") || config().app.isDevelopment) {
-        const devSites = availableSites.filter((site) =>
-          ["dev", "test", "staging", "local"].includes(site.toLowerCase()),
-        );
-        if (devSites.length > 0) {
-          return devSites[0];
-        }
-      }
-
-      // 4. Default to first available site
-      return availableSites[0];
-    }
-
-    // Fallback to 'default' if no sites available
-    return "default";
+  private selectBestSite(): string {
+    const keys = Array.from(this.wordpressClients.keys());
+    return keys[0] ?? "default";
   }
 
   /**


### PR DESCRIPTION
## Summary

- **README version drift**: updated banner from `v2.12.0` → `v3.3.14`; replaced stale v2.x changelog entries with an accurate v3.x series summary and a pointer to `CHANGELOG.md`
- **Dead multi-site heuristics** (`ToolRegistry.ts`): `selectBestSite()` was only ever reached in single-site mode (the multi-site path returns early), making its name-based heuristics unreachable dead code; simplified to one line and removed the now-unused `config` import
- **Global console patching** (`ServerConfiguration.ts`): dotenv v17 calls `console.log()` unless `quiet: true` is set; replaced the unsafe global `console.log`/`console.error` mutation with the `quiet: true` option on `dotenv.config()`

## Test plan

- [x] `npm run build` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 84 test files, 2609 tests, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update documentation, simplify single-site selection logic, and make environment loading silent without mutating global console.

Enhancements:
- Simplify WordPress site selection to always use the single configured site in non-multi-site mode and remove unused multi-site heuristics.

Documentation:
- Refresh README version banner and changelog section to reflect the v3.x release series and direct readers to CHANGELOG.md for full history.

Chores:
- Adjust dotenv configuration to use the quiet option for silent environment loading instead of patching global console output.