### PR TITLE
fix(auth): bound wp_test_auth with 10s timeout and check ping() return value

### DIFF
--- a/src/tools/auth.ts
+++ b/src/tools/auth.ts
@@ -89,18 +89,26 @@ export class AuthTools {
   ): Promise<Record<string, unknown>> {
     const TIMEOUT_MS = 10_000;
     let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    let timedOut = false;
 
     const timeoutSignal = new Promise<never>((_, reject) => {
-      timeoutHandle = setTimeout(
-        () => reject(new Error(`Connection timed out after ${TIMEOUT_MS / 1000}s`)),
-        TIMEOUT_MS,
-      );
+      timeoutHandle = setTimeout(() => {
+        timedOut = true;
+        reject(new Error(`Connection timed out after ${TIMEOUT_MS / 1000}s`));
+      }, TIMEOUT_MS);
     });
 
     try {
       return await Promise.race([
         (async () => {
           const reachable = await client.ping();
+          // Promise.race doesn't cancel the losing branch — if ping() was
+          // still pending when the timeout fired, the race has already
+          // settled by the time it resolves. Stop here instead of making
+          // an unnecessary (and unobserved) getCurrentUser() request.
+          if (timedOut) {
+            throw new Error("Superseded by timeout");
+          }
           if (!reachable) {
             throw new Error(`Site unreachable: ${client.config.baseUrl}`);
           }

--- a/src/tools/auth.ts
+++ b/src/tools/auth.ts
@@ -87,21 +87,42 @@ export class AuthTools {
     client: WordPressClient,
     params: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
+    const TIMEOUT_MS = 10_000;
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+
+    const timeoutSignal = new Promise<never>((_, reject) => {
+      timeoutHandle = setTimeout(
+        () => reject(new Error(`Connection timed out after ${TIMEOUT_MS / 1000}s`)),
+        TIMEOUT_MS,
+      );
+    });
+
     try {
-      await client.ping();
-      const user = await client.getCurrentUser();
-      const siteConfig = client.config;
+      const result = await Promise.race([
+        (async () => {
+          const reachable = await client.ping();
+          if (!reachable) {
+            throw new Error(`Site unreachable: ${client.config.baseUrl}`);
+          }
+          const user = await client.getCurrentUser();
+          const siteConfig = client.config;
 
-      const content =
-        "✅ **Authentication successful!**\n\n" +
-        `**Site:** ${siteConfig.baseUrl}\n` +
-        `**Method:** ${siteConfig.auth.method}\n` +
-        `**User:** ${user.name} (@${user.slug})\n` +
-        `**Roles:** ${user.roles?.join(", ") || "N/A"}\n\n` +
-        "Your WordPress connection is working properly.";
+          const content =
+            "✅ **Authentication successful!**\n\n" +
+            `**Site:** ${siteConfig.baseUrl}\n` +
+            `**Method:** ${siteConfig.auth.method}\n` +
+            `**User:** ${user.name} (@${user.slug})\n` +
+            `**Roles:** ${user.roles?.join(", ") || "N/A"}\n\n` +
+            "Your WordPress connection is working properly.";
 
-      return { content };
+          return { content };
+        })(),
+        timeoutSignal,
+      ]);
+      clearTimeout(timeoutHandle);
+      return result;
     } catch (_error) {
+      clearTimeout(timeoutHandle);
       throw new Error(`Authentication test failed: ${getErrorMessage(_error)}`);
     }
   }

--- a/src/tools/auth.ts
+++ b/src/tools/auth.ts
@@ -98,7 +98,7 @@ export class AuthTools {
     });
 
     try {
-      const result = await Promise.race([
+      return await Promise.race([
         (async () => {
           const reachable = await client.ping();
           if (!reachable) {
@@ -119,11 +119,10 @@ export class AuthTools {
         })(),
         timeoutSignal,
       ]);
-      clearTimeout(timeoutHandle);
-      return result;
     } catch (_error) {
-      clearTimeout(timeoutHandle);
       throw new Error(`Authentication test failed: ${getErrorMessage(_error)}`);
+    } finally {
+      clearTimeout(timeoutHandle);
     }
   }
 

--- a/tests/tools/auth.test.js
+++ b/tests/tools/auth.test.js
@@ -154,6 +154,38 @@ describe("AuthTools", () => {
       }
     });
 
+    it("should not call getCurrentUser if ping resolves after the timeout already fired", async () => {
+      vi.useFakeTimers();
+      try {
+        let resolvePing;
+        mockClient.ping.mockImplementation(
+          () =>
+            new Promise((resolve) => {
+              resolvePing = resolve;
+            }),
+        );
+
+        const authPromise = authTools.handleTestAuth(mockClient, {});
+        // Attach a handler immediately so the eventual rejection isn't
+        // reported as unhandled while timers/microtasks advance below.
+        const assertion = expect(authPromise).rejects.toThrow(
+          "Authentication test failed: Connection timed out after 10s",
+        );
+
+        vi.advanceTimersByTime(10_000);
+        await assertion;
+
+        // ping() finally resolves, but only after the race already settled
+        resolvePing(true);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(mockClient.getCurrentUser).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("should handle getCurrentUser failures after successful ping", async () => {
       // Mock successful ping but failed user fetch
       mockClient.ping.mockResolvedValue(true);

--- a/tests/tools/auth.test.js
+++ b/tests/tools/auth.test.js
@@ -124,6 +124,31 @@ describe("AuthTools", () => {
       expect(mockClient.getCurrentUser).not.toHaveBeenCalled();
     });
 
+    it("should fail immediately when ping returns false without calling getCurrentUser", async () => {
+      // Real ping() never throws — it returns false on failure
+      mockClient.ping.mockResolvedValue(false);
+
+      await expect(authTools.handleTestAuth(mockClient, {})).rejects.toThrow(
+        "Authentication test failed: Site unreachable: https://example.com",
+      );
+
+      expect(mockClient.ping).toHaveBeenCalledTimes(1);
+      expect(mockClient.getCurrentUser).not.toHaveBeenCalled();
+    });
+
+    it("should time out after 10 seconds and not hang indefinitely", async () => {
+      vi.useFakeTimers();
+      // Simulate an unreachable site: ping never resolves
+      mockClient.ping.mockImplementation(() => new Promise(() => {}));
+
+      const authPromise = authTools.handleTestAuth(mockClient, {});
+      vi.advanceTimersByTime(10_000);
+
+      await expect(authPromise).rejects.toThrow("Authentication test failed: Connection timed out after 10s");
+
+      vi.useRealTimers();
+    });
+
     it("should handle getCurrentUser failures after successful ping", async () => {
       // Mock successful ping but failed user fetch
       mockClient.ping.mockResolvedValue(true);

--- a/tests/tools/auth.test.js
+++ b/tests/tools/auth.test.js
@@ -138,15 +138,20 @@ describe("AuthTools", () => {
 
     it("should time out after 10 seconds and not hang indefinitely", async () => {
       vi.useFakeTimers();
-      // Simulate an unreachable site: ping never resolves
-      mockClient.ping.mockImplementation(() => new Promise(() => {}));
+      try {
+        // Simulate an unreachable site: ping never resolves
+        mockClient.ping.mockImplementation(() => new Promise(() => {}));
 
-      const authPromise = authTools.handleTestAuth(mockClient, {});
-      vi.advanceTimersByTime(10_000);
+        const authPromise = authTools.handleTestAuth(mockClient, {});
+        vi.advanceTimersByTime(10_000);
 
-      await expect(authPromise).rejects.toThrow("Authentication test failed: Connection timed out after 10s");
+        await expect(authPromise).rejects.toThrow("Authentication test failed: Connection timed out after 10s");
 
-      vi.useRealTimers();
+        expect(mockClient.ping).toHaveBeenCalledTimes(1);
+        expect(mockClient.getCurrentUser).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("should handle getCurrentUser failures after successful ping", async () => {


### PR DESCRIPTION
## Description

`wp_test_auth` could hang for up to ~3 minutes against an unreachable site (3 retries × 30s × 2 sequential calls: `ping()` then `getCurrentUser()`), and ignored `ping()`'s return value entirely — `ping()` never throws, it returns `false` on failure, but the previous code always proceeded to call `getCurrentUser()` regardless.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Changes Made

- [x] Add an outer `Promise.race` timeout (10s) so `wp_test_auth` always responds within 10s
- [x] Check `ping()`'s return value and fail fast with a clear "Site unreachable" error instead of proceeding to `getCurrentUser()`
- [x] Clear the timeout handle via a `finally` block covering both success and error paths (no dangling timer, no duplicated `clearTimeout` calls)
- [x] Add regression tests for the false-return-ping and timeout scenarios, including assertions that `ping` is called exactly once and `getCurrentUser` is never called when the timeout fires
- [x] Wrap the fake-timer test body in `try`/`finally` so a failing assertion can't leak fake timers into later tests

## Testing

### Tests Performed

- [x] Unit tests pass (`npx vitest run` — 2695 tests / 90 files)
- [x] TypeScript compilation (`npm run build`)
- [x] Linting passes (`npm run lint`)

## Checklist

- [x] New and existing unit tests pass locally with my changes

## Summary by Sourcery

Ensure WordPress authentication tests return promptly and correctly handle unreachable sites.

Bug Fixes:
- Prevent wp_test_auth from hanging by enforcing a 10-second timeout on the authentication check.
- Respect the WordPress client ping() return value and fail fast with a clear site-unreachable error instead of proceeding with user fetch.

Tests:
- Add regression tests covering ping() returning false, timeout behavior, and ensuring getCurrentUser is not called when authentication cannot be established.