### PR TITLE
fix: return raw Gutenberg block markup when full content is requested

### DIFF
--- a/src/client/CachedWordPressClient.ts
+++ b/src/client/CachedWordPressClient.ts
@@ -123,8 +123,8 @@ export class CachedWordPressClient extends WordPressClient {
   /**
    * Get single post with caching
    */
-  async getPost(id: number): Promise<WordPressPost> {
-    return await this.request<WordPressPost>("GET", `posts/${id}`);
+  async getPost(id: number, context: "view" | "embed" | "edit" = "view"): Promise<WordPressPost> {
+    return await this.request<WordPressPost>("GET", `posts/${id}?context=${context}`);
   }
 
   /**

--- a/src/tools/pages.ts
+++ b/src/tools/pages.ts
@@ -1,7 +1,7 @@
 import { WordPressClient } from "@/client/api.js";
 import type { MCPToolSchema } from "@/types/mcp.js";
 import { CreatePageRequest, PostQueryParams as PageQueryParams, UpdatePageRequest } from "@/types/wordpress.js";
-import { getErrorMessage } from "@/utils/error.js";
+import { getErrorMessage, isPermissionError } from "@/utils/error.js";
 import { parseId, parseIdAndForce, toolParams } from "./params.js";
 
 /**
@@ -56,7 +56,8 @@ export class PageTools {
             },
             include_content: {
               type: "boolean",
-              description: "If true, includes the full HTML content of the page. Default: false",
+              description:
+                "If true, includes the full page content as raw source (context=edit), preserving Gutenberg block markup for editing. Default: false",
             },
           },
           required: ["id"],
@@ -172,7 +173,20 @@ export class PageTools {
     const id = parseId(params);
     const { include_content = false } = params as { include_content?: boolean };
     try {
-      const page = await client.getPage(id);
+      let page;
+      if (include_content) {
+        try {
+          page = await client.getPage(id, "edit");
+        } catch (error) {
+          if (!isPermissionError(error)) {
+            throw error;
+          }
+          // Credentials lack edit capability for context=edit — fall back to rendered content
+          page = await client.getPage(id, "view");
+        }
+      } else {
+        page = await client.getPage(id, "view");
+      }
       let content =
         `**Page Details (ID: ${page.id})**\n\n` +
         `- **Title:** ${page.title.rendered}\n` +
@@ -181,7 +195,7 @@ export class PageTools {
         `- **Date:** ${new Date(page.date).toLocaleString()}`;
 
       if (include_content) {
-        content += `\n\n**Content:**\n\n` + `${page.content.rendered || "(empty)"}`;
+        content += `\n\n**Content:**\n\n` + `${(page.content.raw ?? page.content.rendered) || "(empty)"}`;
       }
 
       return content;

--- a/src/tools/posts/PostHandlers.ts
+++ b/src/tools/posts/PostHandlers.ts
@@ -8,7 +8,7 @@
 
 import { WordPressClient } from "@/client/api.js";
 import { CreatePostRequest, PostQueryParams, PostStatus, UpdatePostRequest, WordPressPost } from "@/types/wordpress.js";
-import { getErrorMessage } from "@/utils/error.js";
+import { getErrorMessage, isPermissionError } from "@/utils/error.js";
 import { ErrorHandlers } from "@/utils/enhancedError.js";
 import { validateId, validatePaginationParams, validatePostParams } from "@/utils/validation.js";
 import { sanitizeHtml } from "@/utils/validation/security.js";
@@ -205,7 +205,23 @@ export async function handleGetPost(
 ): Promise<WordPressPost | string> {
   try {
     const postId = validateId(params.id, "post ID");
-    const post = await client.getPost(postId);
+    // Only include full content if explicitly requested (for backward compatibility, default to true).
+    // When content is wanted, fetch with context=edit so content.raw (Gutenberg block markup) is available.
+    const includeContent = params.include_content !== false;
+    let post;
+    if (includeContent) {
+      try {
+        post = await client.getPost(postId, "edit");
+      } catch (error) {
+        if (!isPermissionError(error)) {
+          throw error;
+        }
+        // Credentials lack edit capability for context=edit — fall back to rendered content
+        post = await client.getPost(postId, "view");
+      }
+    } else {
+      post = await client.getPost(postId, "view");
+    }
 
     // Get additional metadata for comprehensive response
     const [author, categories, tags] = await Promise.all([
@@ -241,7 +257,7 @@ export async function handleGetPost(
       minute: "2-digit",
     });
 
-    const content = post.content?.rendered || "";
+    const content = post.content?.raw ?? post.content?.rendered ?? "";
     const excerpt = post.excerpt?.rendered ? sanitizeHtml(post.excerpt.rendered).trim() : "";
     const wordCount = sanitizeHtml(content).split(/\s+/).filter(Boolean).length;
 
@@ -268,8 +284,6 @@ export async function handleGetPost(
       response += `\n## Excerpt\n${excerpt}\n`;
     }
 
-    // Only include full content if explicitly requested (for backward compatibility, default to true)
-    const includeContent = params.include_content !== false;
     if (content && includeContent) {
       response += `\n## Content\n${content}\n`;
     }

--- a/src/tools/posts/PostToolDefinitions.ts
+++ b/src/tools/posts/PostToolDefinitions.ts
@@ -71,7 +71,8 @@ export const getPostTool: MCPTool = {
       },
       include_content: {
         type: "boolean",
-        description: "If true, includes the full HTML content of the post for editing. Default: false",
+        description:
+          "If true, includes the full post content as raw source (context=edit), preserving Gutenberg block markup for editing. Default: true",
       },
     },
     required: ["id"],

--- a/src/types/wordpress.ts
+++ b/src/types/wordpress.ts
@@ -21,6 +21,8 @@ export type WordPressMeta = Record<string, unknown> | unknown[];
 // Common WordPress API response patterns
 export interface WordPressRendered {
   rendered: string;
+  /** Raw (unrendered) source, e.g. Gutenberg block markup. Only present when fetched with context=edit. */
+  raw?: string;
   protected?: boolean;
 }
 

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -22,6 +22,24 @@ function legacyConsoleError(...args: unknown[]) {
 // @__PURE__ This constant has no side effects and can be dropped in production builds
 export const __errorUtilsLogger = logger;
 
+/**
+ * True when an error represents a WordPress REST permission denial (401/403),
+ * e.g. requesting context=edit with credentials that lack edit capability.
+ */
+export function isPermissionError(error: unknown): boolean {
+  if (error && typeof error === "object") {
+    const statusCode = (error as { statusCode?: unknown }).statusCode;
+    if (statusCode === 401 || statusCode === 403) {
+      return true;
+    }
+    const code = (error as { code?: unknown }).code;
+    if (code === "rest_forbidden" || code === "rest_forbidden_context") {
+      return true;
+    }
+  }
+  return /\b(401|403|rest_forbidden)\b/.test(getErrorMessage(error));
+}
+
 export function getErrorMessage(error: unknown): string {
   if (error instanceof Error) {
     return error.message;

--- a/tests/client/CachedWordPressClient.test.js
+++ b/tests/client/CachedWordPressClient.test.js
@@ -144,6 +144,43 @@ describe("CachedWordPressClient", () => {
     });
   });
 
+  describe("getPost context forwarding", () => {
+    it("should request context=edit when asked, so raw Gutenberg markup is fetchable through the cached client", async () => {
+      vi.clearAllMocks();
+
+      await cachedClient.getPost(5, "edit");
+
+      expect(WordPressClient.prototype.requestWithMetadata).toHaveBeenCalledWith(
+        "GET",
+        expect.stringContaining("context=edit"),
+        null,
+        expect.anything(),
+      );
+    });
+
+    it("should default to context=view", async () => {
+      vi.clearAllMocks();
+
+      await cachedClient.getPost(5);
+
+      expect(WordPressClient.prototype.requestWithMetadata).toHaveBeenCalledWith(
+        "GET",
+        expect.stringContaining("context=view"),
+        null,
+        expect.anything(),
+      );
+    });
+
+    it("should cache edit and view contexts separately", async () => {
+      vi.clearAllMocks();
+
+      await cachedClient.getPost(5, "view");
+      await cachedClient.getPost(5, "edit");
+
+      expect(WordPressClient.prototype.requestWithMetadata).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe("request method caching behavior", () => {
     it("should cache GET requests", async () => {
       // Reset call count

--- a/tests/tools/pages.test.js
+++ b/tests/tools/pages.test.js
@@ -231,7 +231,7 @@ describe("PageTools", () => {
 
       const result = await pageTools.handleGetPage(mockClient, { id: 1 });
 
-      expect(mockClient.getPage).toHaveBeenCalledWith(1);
+      expect(mockClient.getPage).toHaveBeenCalledWith(1, "view");
       expect(typeof result).toBe("string");
       expect(result).toContain("Page Details (ID: 1)");
       expect(result).toContain("Test Page");

--- a/tests/tools/pages/PageTools.test.js
+++ b/tests/tools/pages/PageTools.test.js
@@ -172,10 +172,66 @@ describe("PageTools", () => {
     it("should get a page by ID", async () => {
       const result = await pageTools.handleGetPage(mockClient, { id: 1 });
 
-      expect(mockClient.getPage).toHaveBeenCalledWith(1);
+      expect(mockClient.getPage).toHaveBeenCalledWith(1, "view");
       expect(typeof result).toBe("string");
       expect(result).toContain("Test Page");
       expect(result).toContain("Page Details (ID: 1)");
+    });
+
+    it("should fetch with context=edit and prefer raw content when include_content is true", async () => {
+      mockClient.getPage.mockResolvedValue({
+        id: 1,
+        title: { rendered: "Test Page" },
+        content: {
+          raw: "<!-- wp:paragraph --><p>Raw block markup</p><!-- /wp:paragraph -->",
+          rendered: "<p>Raw block markup</p>",
+        },
+        date: "2024-01-01T00:00:00",
+        status: "publish",
+        link: "https://test.wordpress.com/test-page",
+      });
+
+      const result = await pageTools.handleGetPage(mockClient, { id: 1, include_content: true });
+
+      expect(mockClient.getPage).toHaveBeenCalledWith(1, "edit");
+      expect(result).toContain("<!-- wp:paragraph -->");
+    });
+
+    it("should fall back to rendered content when raw is absent", async () => {
+      const result = await pageTools.handleGetPage(mockClient, { id: 1, include_content: true });
+
+      expect(result).toContain("<p>Full page content here</p>");
+    });
+
+    it("should fall back to context=view when context=edit is denied", async () => {
+      const forbidden = Object.assign(new Error("403 rest_forbidden_context"), { statusCode: 403 });
+      mockClient.getPage.mockImplementation((id, context) =>
+        context === "edit"
+          ? Promise.reject(forbidden)
+          : Promise.resolve({
+              id: 1,
+              title: { rendered: "Test Page" },
+              content: { rendered: "<p>Rendered only</p>" },
+              date: "2024-01-01T00:00:00",
+              status: "publish",
+              link: "https://test.wordpress.com/test-page",
+            }),
+      );
+
+      const result = await pageTools.handleGetPage(mockClient, { id: 1, include_content: true });
+
+      expect(mockClient.getPage).toHaveBeenCalledWith(1, "edit");
+      expect(mockClient.getPage).toHaveBeenCalledWith(1, "view");
+      expect(result).toContain("<p>Rendered only</p>");
+    });
+
+    it("should not retry non-permission errors with context=view", async () => {
+      mockClient.getPage.mockRejectedValue(new Error("Page not found"));
+
+      await expect(pageTools.handleGetPage(mockClient, { id: 1, include_content: true })).rejects.toThrow(
+        "Failed to get page: Page not found",
+      );
+      expect(mockClient.getPage).toHaveBeenCalledTimes(1);
     });
 
     it("should handle missing ID parameter", async () => {

--- a/tests/tools/pages/PageTools.test.js
+++ b/tests/tools/pages/PageTools.test.js
@@ -203,6 +203,25 @@ describe("PageTools", () => {
       expect(result).toContain("<p>Full page content here</p>");
     });
 
+    it("should keep empty raw content instead of falling back to rendered HTML", async () => {
+      mockClient.getPage.mockResolvedValue({
+        id: 1,
+        title: { rendered: "Test Page" },
+        content: {
+          raw: "",
+          rendered: "<p>Filter-injected advertisement</p>",
+        },
+        date: "2024-01-01T00:00:00",
+        status: "publish",
+        link: "https://test.wordpress.com/test-page",
+      });
+
+      const result = await pageTools.handleGetPage(mockClient, { id: 1, include_content: true });
+
+      expect(result).not.toContain("Filter-injected advertisement");
+      expect(result).toContain("(empty)");
+    });
+
     it("should fall back to context=view when context=edit is denied", async () => {
       const forbidden = Object.assign(new Error("403 rest_forbidden_context"), { statusCode: 403 });
       mockClient.getPage.mockImplementation((id, context) =>

--- a/tests/tools/posts.test.js
+++ b/tests/tools/posts.test.js
@@ -231,7 +231,7 @@ describe("PostTools", () => {
 
       const result = await postTools.handleGetPost(mockClient, { id: 1 });
 
-      expect(mockClient.getPost).toHaveBeenCalledWith(1);
+      expect(mockClient.getPost).toHaveBeenCalledWith(1, "edit");
       expect(typeof result).toBe("string");
       expect(result).toContain("Test Post");
       expect(result).toContain("Test Content");

--- a/tests/tools/posts/PostTools.test.js
+++ b/tests/tools/posts/PostTools.test.js
@@ -276,6 +276,28 @@ describe("PostTools", () => {
       expect(result).toContain("<!-- wp:paragraph -->");
     });
 
+    it("should keep empty raw content instead of falling back to rendered HTML", async () => {
+      // raw="" means the stored post_content is genuinely empty; rendered may still
+      // contain filter-injected HTML which must not be surfaced as editable content.
+      mockClient.getPost.mockResolvedValue({
+        id: 1,
+        title: { rendered: "Test Post" },
+        content: {
+          raw: "",
+          rendered: "<p>Filter-injected advertisement</p>",
+        },
+        date: "2024-01-01T00:00:00",
+        modified: "2024-01-02T00:00:00",
+        status: "publish",
+        link: "https://test.wordpress.com/test-post",
+        author: 1,
+      });
+
+      const result = await postTools.handleGetPost(mockClient, { id: 1 });
+
+      expect(result).not.toContain("Filter-injected advertisement");
+    });
+
     it("should fall back to context=view when context=edit is denied", async () => {
       const forbidden = Object.assign(new Error("403 rest_forbidden_context"), { statusCode: 403 });
       mockClient.getPost.mockImplementation((id, context) =>

--- a/tests/tools/posts/PostTools.test.js
+++ b/tests/tools/posts/PostTools.test.js
@@ -250,10 +250,54 @@ describe("PostTools", () => {
     it("should get a post by ID", async () => {
       const result = await postTools.handleGetPost(mockClient, { id: 1 });
 
-      expect(mockClient.getPost).toHaveBeenCalledWith(1);
+      expect(mockClient.getPost).toHaveBeenCalledWith(1, "edit");
       expect(typeof result).toBe("string");
       expect(result).toContain("Test Post");
       expect(result).toContain("Full post content here");
+    });
+
+    it("should prefer raw content when available", async () => {
+      mockClient.getPost.mockResolvedValue({
+        id: 1,
+        title: { rendered: "Test Post" },
+        content: {
+          raw: "<!-- wp:paragraph --><p>Raw block markup</p><!-- /wp:paragraph -->",
+          rendered: "<p>Raw block markup</p>",
+        },
+        date: "2024-01-01T00:00:00",
+        modified: "2024-01-02T00:00:00",
+        status: "publish",
+        link: "https://test.wordpress.com/test-post",
+        author: 1,
+      });
+
+      const result = await postTools.handleGetPost(mockClient, { id: 1 });
+
+      expect(result).toContain("<!-- wp:paragraph -->");
+    });
+
+    it("should fall back to context=view when context=edit is denied", async () => {
+      const forbidden = Object.assign(new Error("403 rest_forbidden_context"), { statusCode: 403 });
+      mockClient.getPost.mockImplementation((id, context) =>
+        context === "edit"
+          ? Promise.reject(forbidden)
+          : Promise.resolve({
+              id: 1,
+              title: { rendered: "Test Post" },
+              content: { rendered: "<p>Rendered only</p>" },
+              date: "2024-01-01T00:00:00",
+              modified: "2024-01-02T00:00:00",
+              status: "publish",
+              link: "https://test.wordpress.com/test-post",
+              author: 1,
+            }),
+      );
+
+      const result = await postTools.handleGetPost(mockClient, { id: 1 });
+
+      expect(mockClient.getPost).toHaveBeenCalledWith(1, "edit");
+      expect(mockClient.getPost).toHaveBeenCalledWith(1, "view");
+      expect(result).toContain("<p>Rendered only</p>");
     });
 
     it("should handle missing ID parameter", async () => {


### PR DESCRIPTION
## Problem

`wp_get_page` and `wp_get_post` fetch content with the REST API's default `context=view`, so responses contain only `content.rendered` — final HTML with all Gutenberg block delimiter comments stripped. Any read-modify-write cycle through these tools silently destroys block structure: saving edited rendered HTML back converts the page to a classic HTML blob, breaking block-based layouts (tabs, galleries, third-party blocks like Kadence) and losing all block attributes. The failure is invisible until someone opens the page in the editor.

## Fix

The client operations (`getPage`/`getPost`) already accept a `context` parameter — the tool handlers just never passed it. When full content is requested, handlers now fetch with `context=edit` and prefer `content.raw`.

- `WordPressRendered` gains an optional `raw` field
- `wp_get_page` with `include_content: true` → `context=edit`, returns raw block markup
- `wp_get_post` → same when `include_content` is not `false`
- `CachedWordPressClient.getPost` now forwards the context argument (the override dropped it, so the fix would not take effect with caching enabled — the default); the normalized cache key includes `context`, so view/edit responses are cached separately
- Graceful degradation: on 401/403 (`rest_forbidden`/`rest_forbidden_context`), handlers retry with `context=view`, so read-only credentials behave exactly as before (new `isPermissionError` helper in `utils/error`)
- `??` instead of `||` so legitimately-empty raw content is not replaced by filter-injected rendered HTML
- Corrects `wp_get_post`'s `include_content` description ("Default: false" → actual default is true)

## Testing

- New coverage: context forwarding through the cached client, raw preference, rendered fallback when `raw` is absent, permission fallback, no-retry on non-permission errors, per-context cache keying
- All existing tests pass; lint, typecheck, and the security suite pass via the pre-commit hooks
- Verified against a live WordPress 6.x site with Kadence blocks: created a draft containing block markup, fetched via `context=edit`, got byte-identical raw source back

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure WordPress page and post tools retrieve raw Gutenberg block markup when full content is requested, while preserving backward-compatible behavior for view-only access and caching.

New Features:
- Support fetching raw Gutenberg block markup via context=edit for posts and pages when full content is requested.
- Add a helper to detect WordPress REST permission errors and enable fallback behavior.

Bug Fixes:
- Prevent loss of Gutenberg block structure by preferring raw content over rendered HTML when available.
- Fix incorrect default description for the include_content parameter in the post and page tools.

Enhancements:
- Extend WordPressRendered types to include optional raw source content.
- Update cached WordPress client to accept and forward context for post requests and cache view/edit responses separately.

Tests:
- Add tests covering context forwarding through the cached client, raw-versus-rendered content selection, permission-based fallbacks, and separate caching per context for posts and pages.