### PR TITLE
fix(ci): bound docker-publish job timeout, fix dead retry-on-hang path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: semantic-release
     if: needs.semantic-release.outputs.new-release-published == 'true'
+    # Backstop against the default 6h job timeout: the v3.3.19 release run hung for 6h0m
+    # after the linux/arm64 QEMU emulation crashed mid-`npm ci` ("uncaught target signal 4
+    # (Illegal instruction) - core dumped") — docker/build-push-action never returned, so
+    # nothing here failed fast and the retry step below never got a chance to run.
+    timeout-minutes: 75
     permissions:
       contents: read
       packages: write
@@ -171,6 +176,11 @@ jobs:
 
       - name: 🏗️ Build and Push Docker Image
         id: docker-build
+        # Bounded well under the job's 75m timeout-minutes so a hung/crashed emulation
+        # layer (see job-level comment above) fails fast and leaves time for the retry
+        # step below, instead of consuming the run's entire time budget.
+        timeout-minutes: 30
+        continue-on-error: true
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -189,7 +199,12 @@ jobs:
           sbom: true
 
       - name: 🔄 Retry Docker Build on Failure
-        if: failure() && steps.docker-build.outcome == 'failure'
+        # steps.docker-build.outcome is 'cancelled' (not 'failure') when it hits its own
+        # timeout-minutes, so checking only 'failure' here never fires for a hang/timeout —
+        # exactly what happened on the v3.3.19 release. continue-on-error above plus this
+        # broader outcome check means a hang now gets one bounded retry instead of silently
+        # burning the rest of the job's timeout.
+        if: always() && steps.docker-build.outcome != 'success'
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,10 +201,16 @@ jobs:
       - name: 🔄 Retry Docker Build on Failure
         # steps.docker-build.outcome is 'cancelled' (not 'failure') when it hits its own
         # timeout-minutes, so checking only 'failure' here never fires for a hang/timeout —
-        # exactly what happened on the v3.3.19 release. continue-on-error above plus this
-        # broader outcome check means a hang now gets one bounded retry instead of silently
-        # burning the rest of the job's timeout.
-        if: always() && steps.docker-build.outcome != 'success'
+        # exactly what happened on the v3.3.19 release. Deliberately narrower than
+        # `!= 'success'`: that would also match 'skipped' (e.g. if Docker login fails
+        # earlier, docker-build never runs), which would attempt a build without its
+        # prerequisites and mask the real failure. continue-on-error above means this
+        # custom `if:` is evaluated regardless of docker-build's own outcome (its
+        # continue-on-error keeps the job's default success() check passing), and a
+        # step-level timeout below keeps a second hang from burning the rest of the
+        # job's budget.
+        if: steps.docker-build.outcome == 'failure' || steps.docker-build.outcome == 'cancelled'
+        timeout-minutes: 30
         uses: docker/build-push-action@v6
         with:
           context: .


### PR DESCRIPTION
## Description

Root-cause fix for the v3.3.19 release's Docker Hub publish job, which hung for 6 hours before being killed by GitHub Actions' default job timeout (PR #205's release run).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔧 Refactoring (no functional changes to what gets built/published)

## Root Cause

From the actual job log (`gh run view --job 88765198915 --log` once it finally completed):

```
#28 [linux/arm64 builder 5/9] RUN npm ci --no-audit --prefer-offline
#28 28.16 qemu: uncaught target signal 4 (Illegal instruction) - core dumped
...
#28 [linux/arm64 builder 5/9] RUN npm ci --no-audit --prefer-offline
[... 6 hours later ...]
##[error]The operation was canceled.
```

`linux/arm64` QEMU emulation crashed mid-`npm ci`, and `docker/build-push-action@v6` never returned afterward — likely an orphaned QEMU child process holding a pipe open. `release.yml` had **no `timeout-minutes` anywhere** (job or step level), so the job ran until GitHub Actions' default 6h ceiling finally killed it. The actual Docker Hub push had already completed successfully within the first ~7 minutes (confirmed via `docker hub API` — both `amd64`/`arm64` manifests were `active` with timestamps ~21:23:5x, while the job itself didn't get cancelled until ~03:16 the next day) — only the Actions job wrapper was stuck.

Separately, the workflow already has a "🔄 Retry Docker Build on Failure" step meant for exactly this kind of failure, but its condition (`steps.docker-build.outcome == 'failure'`) can never fire on a hang/timeout: a step that exceeds its own `timeout-minutes` gets outcome `cancelled`, not `failure`. So even with a bounded timeout added, the retry mechanism needed a matching fix to actually engage.

## Changes Made

- [x] `docker-publish` job: `timeout-minutes: 75` as a backstop against the 6h default
- [x] `🏗️ Build and Push Docker Image` step: `timeout-minutes: 30` (bounded, still generous for a cold-cache multi-arch build) + `continue-on-error: true` (so a successful retry can still make the job's overall conclusion "success" instead of "failure")
- [x] `🔄 Retry Docker Build on Failure` condition broadened from `failure() && steps.docker-build.outcome == 'failure'` to `always() && steps.docker-build.outcome != 'success'`, so both a clean failure and a timeout-driven cancellation trigger the retry

## Testing

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — valid YAML
- [x] `actionlint .github/workflows/release.yml` — clean, no findings
- [x] Full local test suite unaffected (workflow-only change): `npx vitest run` — 2785/2785 passing
- [ ] Can't fully simulate a real hung/crashed QEMU build locally — first real signal will be the next scheduled Docker Hub publish run

### Test Cases

Not directly testable without triggering a real release; reasoned through the GitHub Actions `outcome`/`conclusion` semantics for `timeout-minutes` + `continue-on-error` + `if: always()` combinations to confirm the retry step will now actually run and can rescue the job's overall status.

## Documentation

- [x] Project memory updated with the root cause and fix (not part of this diff — internal Claude Code memory, not repo docs)

## Additional Notes

Not a fix for the underlying QEMU/ARM64 emulation flakiness itself (that would need a deeper investigation, possibly native ARM runners or a QEMU version pin) — this bounds the blast radius so a recurrence fails/retries within ~75 minutes instead of consuming 6 hours and leaving a confusing "still running" status, and gives the existing retry mechanism a real chance to self-heal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bound the Docker publish workflow’s job and build step timeouts and adjusted the retry condition so hung or timed-out multi-arch builds fail fast and get a single retry instead of consuming the full GitHub Actions default timeout.

CI:
- Add a 75-minute timeout to the docker-publish job to avoid unbounded 6-hour hangs.
- Set a 30-minute timeout and continue-on-error on the Docker build-and-push step to allow recovery via retry.
- Broaden the retry step condition to rerun the Docker build whenever the initial attempt is non-success, covering both failures and cancellations.