### PR TITLE
fix(docker): strip bundled npm CLI from production image to clear Trivy gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,16 @@ this stack. `main-ci.yml` (4-suite × Node-version matrix), `wordpress-compatibi
 `release.yml` (DXT + Docker Hub + npm in one pipeline), `docker-modern.yml`, `dependency-review.yml` are all
 project-specific by design. `/repo-audit` flags these as P1 — expected and accepted.
 
+**Production Docker image has no npm**: `Dockerfile`'s production stage removes the `node:22-alpine` base image's
+bundled npm CLI (`node_modules`, `npm`, `npx` binaries) entirely — the container's entrypoint only ever runs
+`node dist/index.js` (`CMD`/`HEALTHCHECK`), and `docs/DOCKER.md`'s documented `docker exec` usage only ever invokes
+`node` directly, so npm is never needed at runtime. Do not add a runtime code path (health check, `docker exec`
+instructions, `bin/*.js` scripts run inside the container) that shells out to `npm`/`npx` without restoring it first.
+This also means npm's own vendored dependencies (`tar`, `brace-expansion`, `picomatch`, `sigstore` — CVEs in npm's
+internals that `npm audit --omit=dev` never surfaces since they're not in this project's own dependency tree, but that
+periodically tripped the post-push Trivy HIGH/CRITICAL image-scan gate) are gone from the shipped image; `corepack` is a
+separate package and is unaffected.
+
 ## Development Workflow
 
 Branch naming: `feature/...`, `fix/...`, `chore/...`. Commits: Conventional Commits (`feat:`, `fix:`, `chore:`, etc.).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,29 +11,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - **docker:** the production image's Trivy vulnerability scan started failing on the v3.3.23 release
   (`Total: 6, HIGH: 5, CRITICAL: 1`) — every finding (`tar`, `brace-expansion`, `picomatch`, `sigstore`) was inside
-  `usr/local/lib/node_modules/npm`, the npm CLI bundled with the `node:22-alpine` base image, not the application's own
-  dependencies (`app/node_modules` scanned clean at 0 findings). The container's entrypoint only ever runs
+  `/usr/local/lib/node_modules/npm`, the npm CLI bundled with the `node:22-alpine` base image, not the application's own
+  dependencies (`/app/node_modules` scanned clean at 0 findings). The container's entrypoint only ever runs
   `node dist/index.js` — never `npm` — so the production stage now removes npm's bundled `node_modules` and the
   `npm`/`npx` binaries entirely. Verified locally with Trivy 0.69.3 (matching CI): 6 findings before, 0 after; the built
   image still passes its health check unchanged. `corepack` is a separate package and is left in place.
 
 ## [3.3.23](https://github.com/docdyhr/mcp-wordpress/compare/v3.3.22...v3.3.23) (2026-07-26)
-
-### 🐛 Bug Fixes
-
-- full audit remediation (security, cache, CI, dead code) ([#209](https://github.com/docdyhr/mcp-wordpress/issues/209))
-  ([401e0c9](https://github.com/docdyhr/mcp-wordpress/commit/401e0c9fbd385878bfade376ca8b850022ad2684))
-
-# Changelog
-
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
-[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
-
-Full audit remediation (2026-07-26) — not yet committed/released.
 
 ### 🔒 Security
 
@@ -74,6 +58,8 @@ Full audit remediation (2026-07-26) — not yet committed/released.
 
 ### 🐛 Bug Fixes
 
+- full audit remediation (security, cache, CI, dead code) ([#209](https://github.com/docdyhr/mcp-wordpress/issues/209))
+  ([401e0c9](https://github.com/docdyhr/mcp-wordpress/commit/401e0c9fbd385878bfade376ca8b850022ad2684))
 - **`scripts/health-check.js` (PR #209 review):** `requiredFiles`/`keyFiles` still listed `src/client/auth.ts` and
   `dist/client/auth.js`, deleted in this same remediation's dead-code cleanup, so `npm run health` always reported a
   correctly-built checkout as unhealthy. Removed the stale entries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### 🐛 Bug Fixes
+
+- **docker:** the production image's Trivy vulnerability scan started failing on the v3.3.23 release
+  (`Total: 6, HIGH: 5, CRITICAL: 1`) — every finding (`tar`, `brace-expansion`, `picomatch`, `sigstore`) was inside
+  `usr/local/lib/node_modules/npm`, the npm CLI bundled with the `node:22-alpine` base image, not the application's own
+  dependencies (`app/node_modules` scanned clean at 0 findings). The container's entrypoint only ever runs
+  `node dist/index.js` — never `npm` — so the production stage now removes npm's bundled `node_modules` and the
+  `npm`/`npx` binaries entirely. Verified locally with Trivy 0.69.3 (matching CI): 6 findings before, 0 after; the built
+  image still passes its health check unchanged. `corepack` is a separate package and is left in place.
 
 ## [3.3.23](https://github.com/docdyhr/mcp-wordpress/compare/v3.3.22...v3.3.23) (2026-07-26)
 
 ### 🐛 Bug Fixes
 
-* full audit remediation (security, cache, CI, dead code) ([#209](https://github.com/docdyhr/mcp-wordpress/issues/209)) ([401e0c9](https://github.com/docdyhr/mcp-wordpress/commit/401e0c9fbd385878bfade376ca8b850022ad2684))
+- full audit remediation (security, cache, CI, dead code) ([#209](https://github.com/docdyhr/mcp-wordpress/issues/209))
+  ([401e0c9](https://github.com/docdyhr/mcp-wordpress/commit/401e0c9fbd385878bfade376ca8b850022ad2684))
 
 # Changelog
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,9 +51,10 @@ RUN apk update && apk upgrade && \
 # `docker exec` usage — both invoke `node` directly, never `npm`), so npm's own vendored
 # dependencies (tar, brace-expansion, picomatch, sigstore — used internally for `npm
 # audit`/`npm pack`/provenance signing) are dead weight that periodically trips the
-# post-push Trivy gate with HIGH/CRITICAL findings we can't fix ourselves (same class of
-# issue as the `npm audit`-bundled-deps note in AGENTS.md, just surfacing via the image
-# scan instead). corepack is a separate package and is left in place.
+# post-push Trivy gate with HIGH/CRITICAL findings we can't fix ourselves. See the
+# "Production Docker image has no npm" note in the root AGENTS.md's CI/CD Pipeline
+# section before reintroducing any runtime path that shells out to npm/npx. corepack is
+# a separate package and is left in place.
 RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 
 # Create non-root user for security

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,16 @@ RUN apk update && apk upgrade && \
     apk add --no-cache tini && \
     rm -rf /var/cache/apk/*
 
+# Remove the npm CLI bundled with the base image: the container's entrypoint only ever
+# runs `node dist/index.js` (see CMD/HEALTHCHECK below and docs/DOCKER.md's documented
+# `docker exec` usage — both invoke `node` directly, never `npm`), so npm's own vendored
+# dependencies (tar, brace-expansion, picomatch, sigstore — used internally for `npm
+# audit`/`npm pack`/provenance signing) are dead weight that periodically trips the
+# post-push Trivy gate with HIGH/CRITICAL findings we can't fix ourselves (same class of
+# issue as the `npm audit`-bundled-deps note in AGENTS.md, just surfacing via the image
+# scan instead). corepack is a separate package and is left in place.
+RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
+
 # Create non-root user for security
 RUN addgroup -g 1001 -S nodejs && \
     adduser -S mcp -u 1001 -G nodejs


### PR DESCRIPTION
## Description
The v3.3.23 release's post-push Trivy vulnerability scan failed with 6 findings (HIGH: 5, CRITICAL: 1). All 6 were inside `usr/local/lib/node_modules/npm` — the npm CLI bundled with the `node:22-alpine` base image — not the application's own dependencies (`app/node_modules` scanned clean at 0 findings).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- `Dockerfile`: production stage now removes npm's bundled `node_modules` and the `npm`/`npx` binaries. The container's entrypoint only ever runs `node dist/index.js` (`CMD`/`HEALTHCHECK`), and `docs/DOCKER.md`'s documented `docker exec` usage only ever invokes `node` directly — npm is never needed at runtime. `corepack` is a separate package and is left in place.
- `CHANGELOG.md`: documented the fix.

## Related Issues
Follow-up to the v3.3.23 release (`279d796`), whose `🐳 Publish to Docker Hub` job failed at the `🔍 Trivy Vulnerability Scan (published image)` step:
- CVE-2026-59873 (CRITICAL) / CVE-2026-59874 (HIGH) — `tar`
- CVE-2026-13149 / CVE-2026-14257 (HIGH) — `brace-expansion`
- CVE-2026-33671 (HIGH) — `picomatch`
- CVE-2026-48815 (HIGH) — `sigstore`

Same class of issue as the existing "npm audit bundled deps: tar and brace-expansion inside npm itself can't be fixed by us" note — this time surfacing via the image scan instead of `npm audit`.

## Testing
Verified locally with Trivy 0.69.3 (matching CI's pinned version):
- Pre-fix image: reproduces the exact same 6 findings CI reported (`Total: 6 (HIGH: 5, CRITICAL: 1)`)
- Post-fix image: 0 findings, exit code 0
- Post-fix container: `node dist/index.js --health-check` still passes unchanged
- `npm`/`npx` confirmed absent from the built image; `node` and `corepack` confirmed still present

## Documentation
- [x] CHANGELOG.md updated

## Security
- [x] This change directly addresses a Docker image vulnerability gate failure; no new attack surface introduced (removes unused tooling from the runtime image)

## Checklist
- [x] Build passes (`npm run build`)
- [x] Docker image builds and runs correctly
- [x] No source/test files changed (Dockerfile + CHANGELOG only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Strip the unused npm CLI from the production Docker image to resolve Trivy vulnerability scan failures while keeping the runtime entrypoint unchanged.

Bug Fixes:
- Fix production Docker image Trivy scan failures by removing the bundled npm CLI and its vendored dependencies from the runtime layer.

Documentation:
- Document the Docker image vulnerability fix and its rationale in the Unreleased section of the changelog.