### PR TITLE
docs: add MCP Toplist rank badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![MCP Toplist](https://mcptoplist.com/badge/glama%2Fdocdyhr%2Fmcp-wordpress.svg)](https://mcptoplist.com/server/glama%2Fdocdyhr%2Fmcp-wordpress)
+
 <div align="right">
 <a href="https://railway.com?referralCode=QhjuBc">
   <img width="160" src="https://raw.githubusercontent.com/docdyhr/.github/main/assets/railway-corner-v2@2x.png" alt="Deploy on Railway — $20 free credits">


### PR DESCRIPTION
## Description
Recreates #211 as a signed commit. That PR's content is exactly right — a small README badge from [MCP Toplist](https://mcptoplist.com), which tracks MCP servers across the major registries — but its commit is unsigned, and this repo's branch protection ruleset requires all commits to be signed (`required_signatures`), which blocks it from merging as-is.

## Type of Change
- [x] Documentation update

## Changes Made
- `README.md`: add the MCP Toplist rank badge, identical to the change proposed in #211.

## Related Issues
Closes #211 (superseded by this PR; content credit to @chrstphe).

## Testing
Docs-only change; full suite still passes (2540+ tests), lint/typecheck/format clean via pre-commit/pre-push hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Add an MCP Toplist rank badge to the top of the README for visibility into the project's MCP ranking.