### PR TITLE
chore: reformat CHANGELOG.md to match prettier config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [3.3.24](https://github.com/docdyhr/mcp-wordpress/compare/v3.3.23...v3.3.24) (2026-07-29)
 
 ### 🐛 Bug Fixes
 
-* **docker:** strip bundled npm CLI from production image to clear Trivy gate ([#210](https://github.com/docdyhr/mcp-wordpress/issues/210)) ([191cc5e](https://github.com/docdyhr/mcp-wordpress/commit/191cc5e372646fca8dbc8a892b910bc580ab6b71)), closes [#209](https://github.com/docdyhr/mcp-wordpress/issues/209)
+- **docker:** strip bundled npm CLI from production image to clear Trivy gate
+  ([#210](https://github.com/docdyhr/mcp-wordpress/issues/210))
+  ([191cc5e](https://github.com/docdyhr/mcp-wordpress/commit/191cc5e372646fca8dbc8a892b910bc580ab6b71)), closes
+  [#209](https://github.com/docdyhr/mcp-wordpress/issues/209)
 
 # Changelog
 


### PR DESCRIPTION
## Description
The 3.3.24 release's format-check gate failed on the next push (PR #212's badge merge), even though that PR never touched `CHANGELOG.md`. Root cause: semantic-release's changelog plugin writes its own entries using `*` bullets and unwrapped prose, which doesn't match this repo's prettier config (`-` bullets, prose wrapped at 120 chars). Its commit lands directly on `main` *after* the format-check gate already passed for the triggering PR, so the mismatch goes uncaught until the next push runs the check fresh.

## Type of Change
- [x] Chore (formatting only, no behavior change)

## Changes Made
- `CHANGELOG.md`: reformatted the 3.3.24 entry to match prettier (`npm run format` output, no content changes).

## Note
This is structural and will recur on every future release unless either:
1. The release pipeline reformats + recommits after semantic-release runs, or
2. prettier's config is relaxed to match semantic-release's raw changelog output.

Not attempting either of those here — flagging for awareness, this PR just clears the current failure.

## Testing
Docs-only change; full suite passes, `npm run format:check`/`lint:md` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Adjust CHANGELOG.md introductory paragraph and 3.3.24 bug-fix entry formatting to use wrapped lines and hyphen bullets consistent with Prettier configuration.