### PR TITLE
fix(deps): bump @hono/node-server override to 2.0.12 to clear path traversal CVE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### 🔒 Security
+
+- **deps:** bumped the `@hono/node-server` override from `^1.19.13` to `^2.0.12`, fixing
+  [GHSA-frvp-7c67-39w9](https://github.com/advisories/GHSA-frvp-7c67-39w9) (medium, CVSS 5.9) — a path traversal in
+  `serve-static` on Windows via an encoded backslash (`%5C`). The package is pulled in transitively via
+  `@modelcontextprotocol/sdk`, which still requires `^1.19.9`, so raising this repo's own `overrides` entry was the fix
+  rather than a direct dependency bump. The vulnerable `serveStatic` API is never called by this project or by the SDK's
+  runtime code (confirmed via grep), so this was unreachable even before the fix. Verified the public API the SDK does
+  use at runtime (`getRequestListener`, in `streamableHttp.js`) is unchanged between v1 and v2 per the
+  [v2.0.0 release notes](https://github.com/honojs/node-server/releases/tag/v2.0.0) — the only breaking changes (Node
+  ≥20 requirement, removed Vercel adapter) don't apply here. Full test suite (2540 tests) and build pass unchanged.
+
 ## [3.3.24](https://github.com/docdyhr/mcp-wordpress/compare/v3.3.23...v3.3.24) (2026-07-29)
 
 ### 🐛 Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   runtime code (confirmed via grep), so this was unreachable even before the fix. Verified the public API the SDK does
   use at runtime (`getRequestListener`, in `streamableHttp.js`) is unchanged between v1 and v2 per the
   [v2.0.0 release notes](https://github.com/honojs/node-server/releases/tag/v2.0.0) — the only breaking changes (Node
-  ≥20 requirement, removed Vercel adapter) don't apply here. Full test suite (2540 tests) and build pass unchanged.
+  ≥20 requirement, removed Vercel adapter) don't apply here. Full test suite (2540 tests) and build pass unchanged. Also
+  removed the now-stale `GHSA-frvp-7c67-39w9` entry from `security-exceptions.json`, since
+  `scripts/security-audit-gate.js` confirmed it no longer matches any current finding.
 
 ## [3.3.24](https://github.com/docdyhr/mcp-wordpress/compare/v3.3.23...v3.3.24) (2026-07-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,22 +25,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### 🐛 Bug Fixes
 
-- **docker:** strip bundled npm CLI from production image to clear Trivy gate
-  ([#210](https://github.com/docdyhr/mcp-wordpress/issues/210))
-  ([191cc5e](https://github.com/docdyhr/mcp-wordpress/commit/191cc5e372646fca8dbc8a892b910bc580ab6b71)), closes
-  [#209](https://github.com/docdyhr/mcp-wordpress/issues/209)
-
-# Changelog
-
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
-[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
-
-### 🐛 Bug Fixes
-
 - **docker:** the production image's Trivy vulnerability scan started failing on the v3.3.23 release
   (`Total: 6, HIGH: 5, CRITICAL: 1`) — every finding (`tar`, `brace-expansion`, `picomatch`, `sigstore`) was inside
   `/usr/local/lib/node_modules/npm`, the npm CLI bundled with the `node:22-alpine` base image, not the application's own
@@ -48,6 +32,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   `node dist/index.js` — never `npm` — so the production stage now removes npm's bundled `node_modules` and the
   `npm`/`npx` binaries entirely. Verified locally with Trivy 0.69.3 (matching CI): 6 findings before, 0 after; the built
   image still passes its health check unchanged. `corepack` is a separate package and is left in place.
+  ([#210](https://github.com/docdyhr/mcp-wordpress/issues/210))
+  ([191cc5e](https://github.com/docdyhr/mcp-wordpress/commit/191cc5e372646fca8dbc8a892b910bc580ab6b71)), closes
+  [#209](https://github.com/docdyhr/mcp-wordpress/issues/209)
 
 ## [3.3.23](https://github.com/docdyhr/mcp-wordpress/compare/v3.3.22...v3.3.23) (2026-07-26)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -346,12 +346,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     ]
   },
   "overrides": {
-    "@hono/node-server": "^1.19.13",
+    "@hono/node-server": "^2.0.12",
     "@pact-foundation/pact-node": {
       "@types/request": {
         "form-data": "^4.0.3"

--- a/security-exceptions.json
+++ b/security-exceptions.json
@@ -1,13 +1,5 @@
 {
   "$schema": "Consumed by scripts/security-audit-gate.js — not a third-party tool config.",
   "description": "Production npm audit findings (npm audit --omit=dev) that are reviewed, accepted, and time-boxed. Every entry must have a reviewBy date; scripts/security-audit-gate.js fails the audit gate once that date passes, forcing a conscious renewal or fix rather than a silent standing exception.",
-  "exceptions": [
-    {
-      "id": "GHSA-frvp-7c67-39w9",
-      "package": "@hono/node-server",
-      "severity": "moderate",
-      "reason": "Path traversal in Hono's serve-static feature on Windows via an encoded backslash. This server only ever constructs a StdioServerTransport (see src/index.ts) — it never starts an HTTP listener, so Hono's static-file-serving code path is never reached. The fix (@hono/node-server >=2.0.5) is only resolvable by upgrading @modelcontextprotocol/sdk, which npm reports as a breaking downgrade to 1.24.3 (see package.json overrides and PR #205 commit b899959) — not worth forcing for a code path this project never executes.",
-      "reviewBy": "2026-10-26"
-    }
-  ]
+  "exceptions": []
 }


### PR DESCRIPTION
## Description

Bumps the `@hono/node-server` `overrides` entry from `^1.19.13` to `^2.0.12`, closing [GHSA-frvp-7c67-39w9](https://github.com/advisories/GHSA-frvp-7c67-39w9) (medium, CVSS 5.9 — path traversal in `serve-static` on Windows via an encoded backslash, `%5C`), open as CodeQL alert #206 since 2026-07-22. Also removes the now-stale exception entry for this CVE from `security-exceptions.json`.

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- [x] `package.json`: `overrides["@hono/node-server"]` `^1.19.13` → `^2.0.12`
- [x] `package-lock.json`: regenerated (`@hono/node-server` resolves to `2.0.12` everywhere, `hono` core stays deduped at `4.12.31`)
- [x] `security-exceptions.json`: removed the `GHSA-frvp-7c67-39w9` exception entry — `scripts/security-audit-gate.js` confirms it no longer matches any finding
- [x] `CHANGELOG.md`: added `## [Unreleased]` entry

## Why this is safe

`@hono/node-server` isn't a direct dependency — it's pulled in transitively via `@modelcontextprotocol/sdk` (which still requires `^1.19.9`) and forced to a patched version via this repo's own `overrides` block, same mechanism already used for `tar`, `minimatch`, etc.

- **Not reachable even before the fix**: this server only ever constructs a `StdioServerTransport` (`src/index.ts`) — it never starts an HTTP listener, so Hono's `serveStatic` code path (where the vulnerability lives) is never executed. Confirmed via grep across `src/` and the SDK's runtime `dist/` — the only usages anywhere are `getRequestListener` in the SDK's actual `streamableHttp.js`, and `serve` in an unused example file. This matches the reasoning already recorded in the exception entry being removed here.
- **Public API unchanged**: per the [v2.0.0 release notes](https://github.com/honojs/node-server/releases/tag/v2.0.0), v2 is "the public API stays the same" — including `getRequestListener`, the one function the SDK actually calls at runtime.
- **Breaking changes don't apply**: v2 requires Node ≥20 (this repo already requires `>=20.8.1`) and drops the `@hono/node-server/vercel` adapter (unused here).
- **Peer dependency satisfied**: `@hono/node-server@2.0.12` peer-depends on `hono: "^4"`; the installed `hono` core (`4.12.31`) already satisfies that without touching the `hono` override.
- **Previously blocked, now clear**: the exception being removed noted the fix was once blocked by an npm-reported breaking downgrade of `@modelcontextprotocol/sdk` to `1.24.3`. The SDK has since moved to `1.29.0` in this repo, and the override now resolves cleanly with no conflicts or downgrades.

## Testing

### Tests Performed

- [x] `npm run build` — clean
- [x] `npx vitest run` — 89 files / 2540 tests passed
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] Pre-commit hooks (lint-staged, lint, typecheck, `tests/security/` × 384 tests) — passed on both commits
- [x] Pre-push hooks (full build, memory-safe suite × 2416 tests, security tests × 384 tests, `scripts/security-audit-gate.js`) — passed on both pushes
- [x] `node scripts/security-audit-gate.js` — 0 findings at/above threshold, no stale-exception warning

## Security

- [x] Dependencies updated to secure versions
- [x] No sensitive information committed

## Documentation

- [x] CHANGELOG.md updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update dependency overrides and security configuration to address a path traversal advisory in a transitive server dependency.

Bug Fixes:
- Mitigate GHSA-frvp-7c67-39w9 path traversal vulnerability by overriding @hono/node-server to version ^2.0.12.

Build:
- Regenerate package-lock.json to reflect the updated @hono/node-server override.

Documentation:
- Add an Unreleased changelog entry documenting the @hono/node-server security update and related context.

Chores:
- Remove the obsolete GHSA-frvp-7c67-39w9 entry from security-exceptions.json now that the dependency is patched.