### PR TITLE
fix(ci): pin QEMU setup in release.yml to stop arm64 npm ci crash

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,16 @@ jobs:
       - name: 📥 Checkout Code
         uses: actions/checkout@v6
 
+      - name: 🐳 Set up QEMU (Multi-platform)
+        # Without this, linux/arm64 emulation falls back to whatever QEMU binfmt the
+        # runner image ships by default, which has crashed mid-`npm ci` with "qemu:
+        # uncaught target signal 4 (Illegal instruction) - core dumped" on v3.3.19 and
+        # again on v3.3.25 (both the primary attempt and its retry, identically) —
+        # docker-modern.yml already pins this step and has had zero arm64 crashes across
+        # its last 5 runs, which is why this is believed to be the actual fix rather than
+        # another layer of containment like the timeout/retry/verify steps below.
+        uses: docker/setup-qemu-action@v4
+
       - name: 🐳 Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 


### PR DESCRIPTION
## Summary

- `release.yml`'s `docker-publish` job builds `linux/amd64,linux/arm64` but never explicitly set up QEMU — it relied on whatever binfmt emulator the `ubuntu-latest` runner image ships by default.
- That default QEMU crashes mid-`npm ci` on the emulated `arm64` leg with `qemu: uncaught target signal 4 (Illegal instruction) - core dumped`, then hangs instead of failing fast.
- This exact signature caused the v3.3.19 incident (job ran until the default 6h timeout). PR #207/#208 added job/step timeouts, a retry, and a real `docker pull` verification step to contain the damage and report failure honestly — but none of that fixes the underlying crash.
- It recurred on the v3.3.25 release (2026-07-29): **both** the primary build attempt and the retry hit the identical crash at the identical point (~29s into `npm ci`), each ran its full 30-minute timeout, and the image was never published — `docker.io/docdyhr/mcp-wordpress:3.3.25` doesn't exist, `latest` is still stamped from 3.3.24.
- `docker-modern.yml` already pins `docker/setup-qemu-action@v4` before its buildx setup and has had zero arm64 crashes across its last 5 runs. This PR adds the same step to `release.yml`'s `docker-publish` job.

## Test plan

- [x] YAML validated (`js-yaml`)
- [x] `npx prettier --check` passes on the changed file
- [x] Pre-commit hooks (lint, typecheck, 384 security tests) passed
- [x] Pre-push hooks (build, 2416-test suite across 4 batches, 384 security tests, production dependency audit gate) all passed
- [ ] Next release's Docker publish job should be watched to confirm the arm64 leg no longer crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Add an explicit docker/setup-qemu-action@v4 step to the release.yml docker-publish job to provide a reliable multi-architecture emulator for linux/arm64 builds.