### PR TITLE
chore: reformat CHANGELOG.md to match prettier config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [3.3.25](https://github.com/docdyhr/mcp-wordpress/compare/v3.3.24...v3.3.25) (2026-07-29)
 
 ### 🐛 Bug Fixes
 
-* **deps:** bump @hono/node-server override to 2.0.12 to clear path traversal CVE ([#214](https://github.com/docdyhr/mcp-wordpress/issues/214)) ([b934fe3](https://github.com/docdyhr/mcp-wordpress/commit/b934fe358774f5c3424948d1b2fbe06d99919043))
+- **deps:** bump @hono/node-server override to 2.0.12 to clear path traversal CVE
+  ([#214](https://github.com/docdyhr/mcp-wordpress/issues/214))
+  ([b934fe3](https://github.com/docdyhr/mcp-wordpress/commit/b934fe358774f5c3424948d1b2fbe06d99919043))
 
 ### 📚 Documentation
 
-* add MCP Toplist rank badge to README ([#212](https://github.com/docdyhr/mcp-wordpress/issues/212)) ([caee868](https://github.com/docdyhr/mcp-wordpress/commit/caee8685f4bcddf70ac8d6ad3695f5ab0d2f1d86)), closes [#211](https://github.com/docdyhr/mcp-wordpress/issues/211)
+- add MCP Toplist rank badge to README ([#212](https://github.com/docdyhr/mcp-wordpress/issues/212))
+  ([caee868](https://github.com/docdyhr/mcp-wordpress/commit/caee8685f4bcddf70ac8d6ad3695f5ab0d2f1d86)), closes
+  [#211](https://github.com/docdyhr/mcp-wordpress/issues/211)
 
 # Changelog
 


### PR DESCRIPTION
## Summary

- Same recurring issue as PR #213 (after 3.3.24): semantic-release's auto-generated `## [3.3.25]` changelog entry doesn't match this repo's prettier config.
- This is currently blocking `release.yml`'s Semantic Release job at the Format Check step on every push to `main` — it just failed PR #215's merge-triggered release run for exactly this reason, which means no new release can be cut right now, including a retry at publishing v3.3.25's still-missing Docker image (see PR #215).
- Fix: `prettier --write CHANGELOG.md`, no content changes.

## Test plan

- [x] `npx prettier --check CHANGELOG.md` passes
- [x] Pre-commit hooks (lint, typecheck, 384 security tests) passed
- [x] Pre-push hooks (build, 2416-test suite across 4 batches, 384 security tests, production dependency audit gate) all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Chores:
- Adjust CHANGELOG.md markdown formatting without altering content to resolve Prettier-based format check failures in the release workflow.