### PR TITLE
chore: reformat CHANGELOG.md to match prettier config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [3.3.26](https://github.com/docdyhr/mcp-wordpress/compare/v3.3.25...v3.3.26) (2026-08-02)
 
 ### 🐛 Bug Fixes
 
-* **ci:** pin QEMU setup in release.yml Docker job to stop arm64 npm ci crash ([#215](https://github.com/docdyhr/mcp-wordpress/issues/215)) ([d8cd4b1](https://github.com/docdyhr/mcp-wordpress/commit/d8cd4b19b3921879bb09a85739ad3e3d7fdfc933))
+- **ci:** pin QEMU setup in release.yml Docker job to stop arm64 npm ci crash
+  ([#215](https://github.com/docdyhr/mcp-wordpress/issues/215))
+  ([d8cd4b1](https://github.com/docdyhr/mcp-wordpress/commit/d8cd4b19b3921879bb09a85739ad3e3d7fdfc933))
 
 # Changelog
 


### PR DESCRIPTION
## Description

Reformats `CHANGELOG.md` to satisfy this repo's prettier config. `semantic-release`'s 3.3.26 release commit (`eea11d3`) wrote its own `## [3.3.26]` entry using unwrapped prose and `*` bullets, which doesn't match this repo's prettier settings — invisible at release time since the format-check gate had already passed for the triggering PR, and only surfaces on the *next* push that runs format-check fresh against `CHANGELOG.md`.

That next push was PR #217's merge-triggered release: `format:check` failed at the `🏷️ Semantic Release` job's `🎨 Format Check` step, before `🐳 Publish to Docker Hub` (and its now-rewritten pre-publish Trivy gate) ever got a chance to run.

Same recurring pattern as PR #213 and PR #216 — see `AGENTS.md` release pipeline notes.

## Type of Change

- [x] 📚 Documentation update

## Testing

- [x] `npx prettier --check CHANGELOG.md` — passes after `--write`
- [x] `npm run format:check` — passes (full command used in CI)
- [x] Full local test suite green (pre-push hook: 2418 + 384 tests)

## Summary by Sourcery

Documentation:
- Adjust CHANGELOG.md prose and list formatting for consistency with established documentation style and automated formatting checks.