### PR TITLE
fix(bin): convert dist/index.js path to file:// URL before import

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -34,7 +34,7 @@ jobs:
             path: "tests/tools/ tests/performance/"
             memory: "4096"
           - name: "root-docs"
-            path: "tests/*.test.js tests/docs/"
+            path: "tests/*.test.js tests/docs/ tests/bin/"
             memory: "2048"
 
     steps:

--- a/bin/mcp-wordpress.js
+++ b/bin/mcp-wordpress.js
@@ -10,13 +10,17 @@
 // imported module could never recognize this as its entry point, and the
 // server would silently do nothing (exit 0, no output).
 import path from "path";
-import { fileURLToPath } from "url";
+import { fileURLToPath, pathToFileURL } from "url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+// pathToFileURL is required, not cosmetic: on Windows a bare OS path like
+// "C:\...\dist\index.js" handed to import() is parsed as a "c:" URL scheme,
+// which Node's ESM loader rejects with ERR_UNSUPPORTED_ESM_URL_SCHEME. It's a
+// no-op on POSIX paths, so this is safe cross-platform.
 const mainModule = path.join(__dirname, "..", "dist", "index.js");
-const { main, runHealthCheck } = await import(mainModule);
+const { main, runHealthCheck } = await import(pathToFileURL(mainModule).href);
 
 if (process.argv.includes("--health-check")) {
   await runHealthCheck();

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "test:batch:1": "npm run build && NODE_OPTIONS=\"--max-old-space-size=8192\" vitest run tests/security/ tests/cache/ tests/server/ --no-coverage --reporter=default",
     "test:batch:2": "npm run build && NODE_OPTIONS=\"--max-old-space-size=8192\" vitest run tests/client/ tests/config/ tests/utils/ --no-coverage --reporter=default",
     "test:batch:3": "npm run build && NODE_OPTIONS=\"--max-old-space-size=8192\" vitest run tests/tools/ tests/performance/ --no-coverage --reporter=default",
-    "test:batch:4": "npm run build && NODE_OPTIONS=\"--max-old-space-size=8192\" vitest run tests/*.test.js tests/docs/ --no-coverage --reporter=default",
+    "test:batch:4": "npm run build && NODE_OPTIONS=\"--max-old-space-size=8192\" vitest run tests/*.test.js tests/docs/ tests/bin/ --no-coverage --reporter=default",
     "test:cache": "npm run build && vitest run tests/cache/",
     "test:ci": "npm run build && CI=true NODE_OPTIONS=\"--max-old-space-size=8192\" vitest run --reporter=default",
     "test:ci:safe": "NODE_OPTIONS=\"--max-old-space-size=8192\" npx vitest run --config vitest.ci.config.ts",

--- a/scripts/run-tests-safe.cjs
+++ b/scripts/run-tests-safe.cjs
@@ -31,7 +31,7 @@ const TEST_BATCHES = [
   },
   {
     name: 'Root & Docs',
-    paths: ['tests/*.test.js', 'tests/docs/'],
+    paths: ['tests/*.test.js', 'tests/docs/', 'tests/bin/'],
     timeout: 60000,
   },
 ];

--- a/tests/bin/mcp-wordpress-entry.test.js
+++ b/tests/bin/mcp-wordpress-entry.test.js
@@ -1,6 +1,16 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { spawnSync } from "child_process";
-import { mkdtempSync, mkdirSync, rmSync, cpSync, copyFileSync, symlinkSync, writeFileSync, existsSync } from "fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  cpSync,
+  copyFileSync,
+  symlinkSync,
+  writeFileSync,
+  existsSync,
+  readFileSync,
+} from "fs";
 import { tmpdir } from "os";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
@@ -83,5 +93,21 @@ describe("bin/mcp-wordpress.js entry-point dispatch", () => {
     expect(result.stdout + result.stderr).toContain("Health check failed: no WordPress sites configured");
     // The old bug's signature: silently did nothing at all.
     expect(result.stdout + result.stderr).not.toBe("");
+  });
+
+  // Regression coverage for a second real bug (#221): the dispatch line handed
+  // a bare OS path straight to import(). On POSIX that path starts with "/",
+  // which the ESM loader accepts, so this was invisible on the Linux/macOS
+  // runners CI actually runs on — this repo has no Windows CI job to catch it
+  // at runtime. On Windows the path starts with a drive letter (e.g.
+  // "C:\...\dist\index.js"), which the loader parses as an unsupported "c:"
+  // URL scheme and throws ERR_UNSUPPORTED_ESM_URL_SCHEME before the server
+  // ever starts. Since the failure mode can't be reproduced on this suite's
+  // runners, this asserts the fix (pathToFileURL, a documented no-op on POSIX
+  // paths) is actually in place, so a future refactor can't silently drop it.
+  it("regression: converts the dist/index.js path to a file:// URL before import (Windows ERR_UNSUPPORTED_ESM_URL_SCHEME)", () => {
+    const source = readFileSync(join(repoRoot, "bin/mcp-wordpress.js"), "utf8");
+    expect(source).toMatch(/pathToFileURL\(mainModule\)\.href/);
+    expect(source).not.toMatch(/await import\(mainModule\)/);
   });
 });

--- a/tests/bin/mcp-wordpress-entry.test.js
+++ b/tests/bin/mcp-wordpress-entry.test.js
@@ -107,7 +107,13 @@ describe("bin/mcp-wordpress.js entry-point dispatch", () => {
   // paths) is actually in place, so a future refactor can't silently drop it.
   it("regression: converts the dist/index.js path to a file:// URL before import (Windows ERR_UNSUPPORTED_ESM_URL_SCHEME)", () => {
     const source = readFileSync(join(repoRoot, "bin/mcp-wordpress.js"), "utf8");
-    expect(source).toMatch(/pathToFileURL\(mainModule\)\.href/);
-    expect(source).not.toMatch(/await import\(mainModule\)/);
+    // Asserts pathToFileURL's result specifically is what's passed to import(),
+    // not just that both substrings appear somewhere in the file — and the
+    // negative check blocks any `await import(mainModule)` call, not only the
+    // exact prior spelling, so reformatting can't dodge either assertion.
+    // Anchored on "await" so it doesn't false-match the explanatory comment
+    // above (which quotes the old `import(mainModule)` form by name).
+    expect(source).toMatch(/await\s+import\(\s*pathToFileURL\(mainModule\)\.href\s*\)/);
+    expect(source).not.toMatch(/await\s+import\(\s*mainModule\s*\)/);
   });
 });


### PR DESCRIPTION
bin/mcp-wordpress.js handed a bare OS path from path.join() straight to import(). On Windows that path starts with a drive letter (e.g. C:\...\dist\index.js), which Node's ESM loader parses as an unsupported c: URL scheme and rejects with
ERR_UNSUPPORTED_ESM_URL_SCHEME before the server ever starts — breaking the standard `npx -y mcp-wordpress` invocation documented for MCP clients. pathToFileURL(...).href is a no-op on POSIX paths, so this is safe on all platforms.

Fixes #221

# Pull Request

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvements
- [ ] 🔒 Security fix

## Changes Made

- [ ] Change 1
- [ ] Change 2
- [ ] Change 3

## Related Issues

Fixes #(issue_number) Closes #(issue_number) Related to #(issue_number)

## Testing

### Test Environment

- [ ] Local development environment
- [ ] WordPress version: [e.g. 6.4.2]
- [ ] Node.js version: [e.g. 18.17.0]
- [ ] Authentication method tested: [e.g. App Passwords, JWT]

### Tests Performed

- [ ] Unit tests pass (`npm test`)
- [ ] Health check passes (`npm run health`)
- [ ] TypeScript compilation (`npm run build`)
- [ ] Linting passes (`npm run lint`)
- [ ] Manual testing performed

### Test Cases

Describe the test cases you executed:

1. Test case 1
2. Test case 2
3. Test case 3

## Screenshots (if applicable)

Add screenshots to help explain your changes.

## Breaking Changes

If this is a breaking change, describe:

1. What breaks
2. How to migrate existing setups
3. Why this change was necessary

## Documentation

- [ ] Documentation updated (if needed)
- [ ] CLAUDE.md updated (if architecture changes)
- [ ] README updated (if user-facing changes)
- [ ] CHANGELOG.md updated

## Code Quality

- [ ] Code follows the project's style guidelines
- [ ] Self-review of code completed
- [ ] Code is well-commented, particularly complex areas
- [ ] No unnecessary console.log statements
- [ ] Error handling is appropriate
- [ ] Performance considerations addressed

## Security

- [ ] No sensitive information (credentials, tokens, etc.) committed
- [ ] Input validation added where appropriate
- [ ] Authorization checks implemented where needed
- [ ] Dependencies updated to secure versions

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

Add any additional notes, considerations, or context for reviewers.

## Summary by Sourcery

Fix the MCP WordPress CLI entry point to correctly import the built dist/index.js module across platforms and add regression coverage for the issue.

Bug Fixes:
- Ensure the bin/mcp-wordpress.js script converts the dist/index.js filesystem path to a file:// URL before dynamic import so it works on Windows and POSIX environments.

Tests:
- Add a regression test that asserts bin/mcp-wordpress.js uses pathToFileURL(mainModule).href instead of importing the bare filesystem path, guarding against future regressions of the Windows ERR_UNSUPPORTED_ESM_URL_SCHEME issue.