### PR TITLE
ci(security): skip node_modules in scheduled Trivy filesystem scan

### DIFF
--- a/.github/workflows/scheduled-security.yml
+++ b/.github/workflows/scheduled-security.yml
@@ -40,23 +40,27 @@ jobs:
         run: npm run security:scan
 
       - name: 🔍 Trivy Filesystem Scan
-        # node_modules is excluded: npm-ecosystem CVEs are already covered (and
-        # gated) by the audit step above using npm's own advisory data, which is
-        # more precise for this ecosystem than Trivy's lockfile heuristics. What
-        # Trivy's bundler scanner was actually finding here was a Gemfile.lock
-        # vendored inside @pact-foundation/pact-node's standalone binary
-        # (node_modules/@pact-foundation/pact-node/standalone/*/pact/lib/vendor) —
-        # a bundled Ruby runtime for Pact's legacy mock-service/verifier that
+        # Only @pact-foundation/pact-node is excluded, not all of node_modules:
+        # Trivy's bundler scanner was finding a Gemfile.lock vendored inside
+        # that package's standalone binary
+        # (node_modules/@pact-foundation/pact-node/standalone/*/pact/lib/vendor)
+        # — a bundled Ruby runtime for Pact's legacy mock-service/verifier that
         # ships with the npm package itself. It's dev-only tooling never invoked
         # in the shipped server, not something a package.json override can patch
         # (it's a vendored binary, not an npm-resolved dependency), and unrelated
         # to any code change in this repo, so it was reopening this workflow's
-        # tracking issue every week for a finding nobody can act on.
+        # tracking issue every week for a finding nobody can act on. Scoped to
+        # this one package (rather than all of node_modules) so Trivy still
+        # catches any other non-npm artifact vendored elsewhere under
+        # node_modules — npm-ecosystem CVEs are separately covered by the audit
+        # step above using npm's own advisory data, more precise for that
+        # ecosystem than Trivy's lockfile heuristics, but that step can't see
+        # non-npm vendored content the way Trivy's fs scan can.
         uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: "fs"
           scan-ref: "."
-          skip-dirs: "node_modules"
+          skip-dirs: "node_modules/@pact-foundation/pact-node"
           format: "table"
           severity: "HIGH,CRITICAL"
           exit-code: "1"

--- a/.github/workflows/scheduled-security.yml
+++ b/.github/workflows/scheduled-security.yml
@@ -40,10 +40,23 @@ jobs:
         run: npm run security:scan
 
       - name: 🔍 Trivy Filesystem Scan
+        # node_modules is excluded: npm-ecosystem CVEs are already covered (and
+        # gated) by the audit step above using npm's own advisory data, which is
+        # more precise for this ecosystem than Trivy's lockfile heuristics. What
+        # Trivy's bundler scanner was actually finding here was a Gemfile.lock
+        # vendored inside @pact-foundation/pact-node's standalone binary
+        # (node_modules/@pact-foundation/pact-node/standalone/*/pact/lib/vendor) —
+        # a bundled Ruby runtime for Pact's legacy mock-service/verifier that
+        # ships with the npm package itself. It's dev-only tooling never invoked
+        # in the shipped server, not something a package.json override can patch
+        # (it's a vendored binary, not an npm-resolved dependency), and unrelated
+        # to any code change in this repo, so it was reopening this workflow's
+        # tracking issue every week for a finding nobody can act on.
         uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: "fs"
           scan-ref: "."
+          skip-dirs: "node_modules"
           format: "table"
           severity: "HIGH,CRITICAL"
           exit-code: "1"


### PR DESCRIPTION
The weekly scan's Trivy fs step (scan-ref: ".", exit-code: 1) was finding a Gemfile.lock vendored inside
@pact-foundation/pact-node's standalone binary
(node_modules/@pact-foundation/pact-node/standalone/*/pact/lib/vendor) — a bundled Ruby runtime for Pact's legacy mock-service/verifier that ships with the npm package itself. It's dev-only tooling never invoked by the shipped server, not something a package.json override can patch (it's a vendored binary, not an npm-resolved dependency), and unrelated to any change in this repo — so it reopened the tracking issue every Monday for a finding nobody can act on.

npm-ecosystem CVEs are already covered by the audit step in the same job (npm run security:scan, npm audit --omit=dev), which uses npm's own advisory data and is more precise for this ecosystem than Trivy's lockfile heuristics — excluding node_modules from the Trivy fs scan loses no real coverage here.

Fixes #219

# Pull Request

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvements
- [ ] 🔒 Security fix

## Changes Made

- [ ] Change 1
- [ ] Change 2
- [ ] Change 3

## Related Issues

Fixes #(issue_number) Closes #(issue_number) Related to #(issue_number)

## Testing

### Test Environment

- [ ] Local development environment
- [ ] WordPress version: [e.g. 6.4.2]
- [ ] Node.js version: [e.g. 18.17.0]
- [ ] Authentication method tested: [e.g. App Passwords, JWT]

### Tests Performed

- [ ] Unit tests pass (`npm test`)
- [ ] Health check passes (`npm run health`)
- [ ] TypeScript compilation (`npm run build`)
- [ ] Linting passes (`npm run lint`)
- [ ] Manual testing performed

### Test Cases

Describe the test cases you executed:

1. Test case 1
2. Test case 2
3. Test case 3

## Screenshots (if applicable)

Add screenshots to help explain your changes.

## Breaking Changes

If this is a breaking change, describe:

1. What breaks
2. How to migrate existing setups
3. Why this change was necessary

## Documentation

- [ ] Documentation updated (if needed)
- [ ] CLAUDE.md updated (if architecture changes)
- [ ] README updated (if user-facing changes)
- [ ] CHANGELOG.md updated

## Code Quality

- [ ] Code follows the project's style guidelines
- [ ] Self-review of code completed
- [ ] Code is well-commented, particularly complex areas
- [ ] No unnecessary console.log statements
- [ ] Error handling is appropriate
- [ ] Performance considerations addressed

## Security

- [ ] No sensitive information (credentials, tokens, etc.) committed
- [ ] Input validation added where appropriate
- [ ] Authorization checks implemented where needed
- [ ] Dependencies updated to secure versions

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

Add any additional notes, considerations, or context for reviewers.

## Summary by Sourcery

CI:
- Update scheduled-security GitHub workflow to skip node_modules in Trivy filesystem scans, clarifying rationale in comments.