### PR TITLE
fix(release): reformat CHANGELOG.md to match prettier config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [3.3.28](https://github.com/docdyhr/mcp-wordpress/compare/v3.3.27...v3.3.28) (2026-08-11)
 
 ### 🐛 Bug Fixes
 
-* **bin:** convert dist/index.js path to file:// URL before import ([#226](https://github.com/docdyhr/mcp-wordpress/issues/226)) ([a94c25c](https://github.com/docdyhr/mcp-wordpress/commit/a94c25cdfdaafbc910077cffc70253e9bee2924e)), closes [#221](https://github.com/docdyhr/mcp-wordpress/issues/221)
+- **bin:** convert dist/index.js path to file:// URL before import
+  ([#226](https://github.com/docdyhr/mcp-wordpress/issues/226))
+  ([a94c25c](https://github.com/docdyhr/mcp-wordpress/commit/a94c25cdfdaafbc910077cffc70253e9bee2924e)), closes
+  [#221](https://github.com/docdyhr/mcp-wordpress/issues/221)
 
 ### 📚 Documentation
 
-* **security:** document read-only root filesystem hardening ([#220](https://github.com/docdyhr/mcp-wordpress/issues/220)) ([80ae710](https://github.com/docdyhr/mcp-wordpress/commit/80ae710a0f0d0c1d6ab7113f3740391464fb29f8))
+- **security:** document read-only root filesystem hardening
+  ([#220](https://github.com/docdyhr/mcp-wordpress/issues/220))
+  ([80ae710](https://github.com/docdyhr/mcp-wordpress/commit/80ae710a0f0d0c1d6ab7113f3740391464fb29f8))
 
 ## [3.3.27](https://github.com/docdyhr/mcp-wordpress/compare/v3.3.26...v3.3.27) (2026-08-04)
 


### PR DESCRIPTION
## Summary
- Fixes the `format:check` gate in `release.yml`, which was failing on `main` (run [#31493583621](https://github.com/docdyhr/mcp-wordpress/actions/runs/31493583621), commit `eb8ec1a`) because `CHANGELOG.md` didn't match prettier's line-wrap/list-marker rules
- This blocks every release until fixed — recurring class of issue (see PRs #213, #216, #225), reintroduced by #228's changelog cleanup
- No content changes — pure reformatting (list markers `*` → `-`, line wrapping)

## Test plan
- [x] `npx prettier --check CHANGELOG.md` passes
- [x] `npm run format:check` (matches release.yml's check exactly) passes
- [x] Full pre-push suite: 2438 tests passed, 0 failed
- [x] Production dependency audit gate: 0 findings above threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Reformat CHANGELOG.md line wrapping and list markers without altering any release notes content.