### PR TITLE
fix(release): stop semantic-release from duplicating the changelog header

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -46,7 +46,7 @@
       "@semantic-release/changelog",
       {
         "changelogFile": "CHANGELOG.md",
-        "changelogTitle": "# Changelog\n\nAll notable changes to this project will be documented in this file.\n\nThe format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),\nand this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)."
+        "changelogTitle": "# Changelog\n\nAll notable changes to this project will be documented in this file.\n\nThe format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to\n[Semantic Versioning](https://semver.org/spec/v2.0.0.html)."
       }
     ],
     [

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,14 @@ internals that `npm audit --omit=dev` never surfaces since they're not in this p
 periodically tripped the post-push Trivy HIGH/CRITICAL image-scan gate) are gone from the shipped image; `corepack` is a
 separate package and is unaffected.
 
+**`.releaserc.json`'s `changelogTitle` must byte-match Prettier's output**: `@semantic-release/changelog` only skips
+prepending a fresh `# Changelog` header when the live `CHANGELOG.md` already `startsWith()` the configured
+`changelogTitle` — a byte-exact check (`node_modules/@semantic-release/changelog/lib/prepare.js`). Prettier's
+`proseWrap: "always"` wraps the intro paragraph at a specific point; if `changelogTitle` wraps it differently, the check
+silently fails on every release and prepends a duplicate header, compounding on each subsequent release (hit in the
+3.3.29 release commit). If `.prettierrc.json`'s `printWidth`/`proseWrap` or the intro text ever change, run
+`npx prettier --write CHANGELOG.md` and copy the new byte-exact header into `changelogTitle`.
+
 ## Development Workflow
 
 Branch naming: `feature/...`, `fix/...`, `chore/...`. Commits: Conventional Commits (`feat:`, `fix:`, `chore:`, etc.).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,22 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [3.3.29](https://github.com/docdyhr/mcp-wordpress/compare/v3.3.28...v3.3.29) (2026-08-12)
 
 ### 🐛 Bug Fixes
 
-* audit follow-ups (deps override, README badge, changelog cleanup, dynamic import) ([#228](https://github.com/docdyhr/mcp-wordpress/issues/228)) ([eb8ec1a](https://github.com/docdyhr/mcp-wordpress/commit/eb8ec1a8b45cc837d4865d0b278248eccb9dcb2f))
-* **release:** reformat CHANGELOG.md to match prettier config ([#229](https://github.com/docdyhr/mcp-wordpress/issues/229)) ([b5b16ed](https://github.com/docdyhr/mcp-wordpress/commit/b5b16ed2f689f4112c008228b2aa53bf5b83146f))
-
-# Changelog
-
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
-[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+- audit follow-ups (deps override, README badge, changelog cleanup, dynamic import)
+  ([#228](https://github.com/docdyhr/mcp-wordpress/issues/228))
+  ([eb8ec1a](https://github.com/docdyhr/mcp-wordpress/commit/eb8ec1a8b45cc837d4865d0b278248eccb9dcb2f))
+- **release:** reformat CHANGELOG.md to match prettier config
+  ([#229](https://github.com/docdyhr/mcp-wordpress/issues/229))
+  ([b5b16ed](https://github.com/docdyhr/mcp-wordpress/commit/b5b16ed2f689f4112c008228b2aa53bf5b83146f))
 
 ## [3.3.28](https://github.com/docdyhr/mcp-wordpress/compare/v3.3.27...v3.3.28) (2026-08-11)
 

--- a/package.json
+++ b/package.json
@@ -113,7 +113,8 @@
       "prettier --write"
     ],
     "*.md": [
-      "markdownlint --fix"
+      "markdownlint --fix",
+      "prettier --write"
     ],
     "package.json": [
       "sort-package-json"


### PR DESCRIPTION
## Summary
- **Root cause found**: `@semantic-release/changelog` decides whether to prepend a fresh header by checking `currentFile.startsWith(changelogTitle)` byte-for-byte (see `node_modules/@semantic-release/changelog/lib/prepare.js`). The hardcoded `changelogTitle` in `.releaserc.json` wrapped its intro paragraph at a different line-break point than Prettier does, so the check silently failed on every release after any Prettier reformat.
- Each mismatch caused the release commit to prepend a **full duplicate `# Changelog` header** (with unformatted `*` bullets) on top of the existing content — compounding indefinitely with every release. This already happened once, in the `3.3.29` release commit (`e296db8`), which is what triggered this investigation.
- This is the actual root cause behind the recurring `format:check` failures fixed ad-hoc in #218, #225, and #229 — those PRs treated the symptom (reformat the file) without fixing why it kept recurring.

## Changes
- Remove the duplicate header/intro block that 3.3.29's release commit added to `CHANGELOG.md`, no content lost
- Reformat the recovered entries to match Prettier
- Rewrap `changelogTitle` in `.releaserc.json` to exactly match Prettier's output — verified directly against the plugin's real `startsWith()` logic (see test plan)
- Add `prettier --write` to the `*.md` lint-staged glob (previously only `markdownlint --fix` ran), so a human editing `CHANGELOG.md` locally can't drift from Prettier's format either

## Known residual (not fixed here, flagging for visibility)
Semantic-release's own commit still writes new changelog entries with raw `*` bullets / unwrapped lines — never passed through Prettier — so `format:check` can still fail on the *next* PR that touches `CHANGELOG.md` after a release, same as before. It just won't compound into duplicate headers anymore. Closing that fully would mean converting `.releaserc.json` to a JS config with a custom `prepare` step running `prettier --write` before the release commit (no new dependency needed — Prettier's already installed) — a bigger structural change, left as a follow-up.

## Test plan
- [x] `.releaserc.json` is valid JSON
- [x] `npx prettier --check CHANGELOG.md` passes
- [x] `npm run format:check` / `npm run lint` / `npm run typecheck` all pass
- [x] Simulated the plugin's exact `startsWith()` check in Node against the fixed `changelogTitle` and the fixed `CHANGELOG.md` — confirmed `true`
- [x] Full pre-push suite: 2438 tests passed, 0 failed
- [x] Production dependency audit gate: 0 findings above threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align changelog formatting and release configuration to prevent duplicated changelog headers in future semantic-release runs.

Bug Fixes:
- Remove the duplicated top-level changelog header and intro block introduced in the 3.3.29 release commit.

Enhancements:
- Reformat recent changelog entries to match Prettier's markdown style, including bullet and line wrapping.
- Update semantic-release configuration to use a changelog title that exactly matches Prettier's formatted output, ensuring the plugin correctly detects the existing header.

Build:
- Extend lint-staged for markdown files to run Prettier alongside markdownlint, keeping local edits aligned with the enforced formatting.