### PR TITLE
fix(release): reformat CHANGELOG.md's 3.3.30 entry to match prettier config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### 🐛 Bug Fixes
 
-* **release:** stop semantic-release from duplicating the changelog header ([#230](https://github.com/docdyhr/mcp-wordpress/issues/230)) ([97dd355](https://github.com/docdyhr/mcp-wordpress/commit/97dd355f57d82fea3c6b5cb74810c1c6bb516b35))
+- **release:** stop semantic-release from duplicating the changelog header
+  ([#230](https://github.com/docdyhr/mcp-wordpress/issues/230))
+  ([97dd355](https://github.com/docdyhr/mcp-wordpress/commit/97dd355f57d82fea3c6b5cb74810c1c6bb516b35))
 
 ## [3.3.29](https://github.com/docdyhr/mcp-wordpress/compare/v3.3.28...v3.3.29) (2026-08-12)
 


### PR DESCRIPTION
## Summary
- Semantic-release's own release commit for 3.3.30 wrote its new changelog entry with a raw `*` bullet and an unwrapped 238-char line — straight from the conventional-changelog template, never passed through Prettier.
- This is exactly the residual risk flagged in #230's own PR description: the header-duplication bug is fixed there, but new entries still aren't Prettier-formatted at write time, so `format:check` can fail again on the *next* release. It just did — blocking `3.3.31` (triggered automatically by #231's `fix:` commit).
- Pure reformatting, no content change (bullet marker `*` → `-`, line wrapped across 3 lines).

## Test plan
- [x] `npx prettier --check CHANGELOG.md` passes
- [x] `npm run format:check` passes
- [x] `changelogTitle`/`startsWith()` invariant still holds (verified against the plugin's actual check)
- [x] Only one `# Changelog` header (no duplication regression)
- [x] Full pre-push suite: all tests passed
- [x] Production dependency audit gate: 0 findings above threshold

A follow-up PR will convert `.releaserc.json` to a JS config with a custom `prepare` step that runs Prettier's JS API on `CHANGELOG.md` before every release commit, closing this class of bug permanently instead of patching it by hand each time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Adjust the 3.3.30 changelog bug-fix entry formatting to match project Prettier configuration without altering its content.