### PR TITLE
fix: don't classify local upload/validation 403s as auth errors

### DIFF
--- a/src/server/ToolRegistry.ts
+++ b/src/server/ToolRegistry.ts
@@ -1,7 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { WordPressClient } from "@/client/api.js";
-import { WordPressAPIError } from "@/types/client.js";
+import { AuthenticationError, WordPressAPIError } from "@/types/client.js";
 import { getErrorMessage } from "@/utils/error.js";
 import { EnhancedError, ErrorHandlers } from "@/utils/enhancedError.js";
 import * as Tools from "@/tools/index.js";
@@ -432,8 +432,19 @@ export class ToolRegistry {
    * `statusCode` rather than `instanceof AuthenticationError` also catches a bare 401 on a
    * non-media endpoint, which the client throws as a plain `WordPressAPIError`, not the
    * `AuthenticationError` subclass (that subtype is only used for media-upload 401/403).
+   *
+   * A bare 403 from WordPress is treated as a permission denial (auth-related). But a 403
+   * carrying an explicit error code is NOT: `validateFilePath`
+   * (src/utils/validation/security.ts) throws 403s like `UPLOADS_DISABLED`,
+   * `PATH_TRAVERSAL_ATTEMPT`, `SYMLINK_NOT_ALLOWED`, `NOT_A_REGULAR_FILE` that are local
+   * configuration/validation failures, not authentication problems. Classifying them as
+   * authentication errors here made `wp_upload_media` report "Authentication failed for site
+   * 'default'" when the real cause was that MCP_UPLOAD_BASE_DIR was not set — hiding the
+   * actual fix behind a misleading credentials error.
    */
   private isAuthenticationError(error: unknown): boolean {
-    return error instanceof WordPressAPIError && (error.statusCode === 401 || error.statusCode === 403);
+    if (error instanceof AuthenticationError) return true;
+    if (!(error instanceof WordPressAPIError)) return false;
+    return error.statusCode === 401 || (error.statusCode === 403 && error.code === undefined);
   }
 }

--- a/tests/server/ToolRegistry.test.js
+++ b/tests/server/ToolRegistry.test.js
@@ -343,6 +343,12 @@ describe("ToolRegistry", () => {
       expect(registry.isAuthenticationError(new WordPressAPIError("Not found", 404))).toBe(false);
     });
 
+    it("does not treat a 403 with an explicit local code (e.g. UPLOADS_DISABLED) as an authentication error", () => {
+      expect(registry.isAuthenticationError(new WordPressAPIError("Uploads disabled", 403, "UPLOADS_DISABLED"))).toBe(
+        false,
+      );
+    });
+
     it("does not treat a plain Error as an authentication error", () => {
       expect(registry.isAuthenticationError(new Error("boom"))).toBe(false);
     });


### PR DESCRIPTION
## Problem

`wp_upload_media` reports a misleading `Authentication failed for site 'default'` error when local uploads are not configured (`MCP_UPLOAD_BASE_DIR` unset).

Root cause:

1. Local uploads are disabled by default and require `MCP_UPLOAD_BASE_DIR` to point at an existing directory.
2. When unset, `validateFilePath` (`src/utils/validation/security.ts`) throws a local 403 with code `UPLOADS_DISABLED` before any request reaches WordPress.
3. `ToolRegistry.isAuthenticationError` treated *every* `statusCode === 403` as an auth failure, so this local config error was wrapped into `Authentication failed for site 'default'`, hiding the real cause.

## Fix

`src/server/ToolRegistry.ts` — narrow the auth-error check:

- `AuthenticationError` instance, `401`, and bare `403` (no `code`) → still treated as authentication errors (existing tests unchanged).
- `403` carrying an explicit local code (`UPLOADS_DISABLED`, `PATH_TRAVERSAL_ATTEMPT`, etc.) → no longer misclassified.

After the fix, upload errors surface the real guidance:
`Local file uploads are disabled. Set MCP_UPLOAD_BASE_DIR to an explicit, existing directory to enable them.`

`tests/server/ToolRegistry.test.js` — added assertion that a 403 with an explicit local code is *not* an authentication error.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Testing

- `npm run build` (tsc) passes — verified `AuthenticationError` import and `error.code` access type-check.
- New test covers the `403 + UPLOADS_DISABLED` case; existing auth-detection tests remain green.

## Related Issues

None.

## Summary by Sourcery

Distinguish local upload configuration and validation failures from authentication errors so users receive the correct guidance.

Bug Fixes:
- Prevent local upload and file-validation 403 errors from being reported as authentication failures.

Enhancements:
- Preserve authentication handling for AuthenticationError instances, 401 responses, and bare 403 responses while distinguishing explicitly coded local errors.

Tests:
- Add coverage confirming that a 403 with an explicit local error code is not classified as an authentication error.