### PR TITLE
fix(seo): detect SEO plugins from the REST plugin path, not a missing slug

### DIFF
--- a/src/client/SEOWordPressClient.ts
+++ b/src/client/SEOWordPressClient.ts
@@ -25,14 +25,21 @@ import type { SchemaType } from "@/types/seo.js";
 import type { SEOMetadata, SchemaMarkup } from "@/types/seo.js";
 
 /**
- * WordPress Plugin interface for API responses
+ * WordPress Plugin interface for API responses.
+ *
+ * GET /wp/v2/plugins identifies a plugin by `plugin` — its file path relative to the
+ * plugins directory with the .php extension stripped, e.g. "wordpress-seo/wp-seo". The
+ * response carries no `slug` field; it stays optional here only so callers holding a
+ * hand-built object still type-check.
  */
 interface WordPressPlugin {
-  slug: string;
+  plugin: string;
   status: "active" | "inactive";
+  slug?: string;
   name?: string;
   description?: string;
   version?: string;
+  textdomain?: string;
 }
 
 /**
@@ -182,6 +189,17 @@ export class SEOWordPressClient extends WordPressClient {
   /**
    * Detect active SEO plugins on the WordPress site
    */
+  /**
+   * Derives a plugin slug from a /wp/v2/plugins entry. The REST response has no `slug`
+   * field, so the slug is the directory segment of `plugin`: "seo-by-rank-math/rank-math"
+   * yields "seo-by-rank-math". Matching the whole segment rather than a prefix keeps
+   * "seo-by-rank-math-pro" from being mistaken for the base plugin. An explicit `slug`,
+   * if some caller supplied one, takes precedence.
+   */
+  private static pluginSlug(plugin: WordPressPlugin): string {
+    return plugin.slug ?? plugin.plugin?.split("/")[0] ?? "";
+  }
+
   private async detectSEOPlugins(): Promise<void> {
     try {
       // Get list of installed plugins
@@ -193,22 +211,26 @@ export class SEOWordPressClient extends WordPressClient {
       }
 
       // Check for active SEO plugins in order of preference
-      const activePlugins = (plugins as WordPressPlugin[]).filter((plugin) => plugin.status === "active");
+      const activeSlugs = new Set(
+        (plugins as WordPressPlugin[])
+          .filter((plugin) => plugin.status === "active")
+          .map((plugin) => SEOWordPressClient.pluginSlug(plugin)),
+      );
 
       // Check for Yoast SEO
-      if (activePlugins.some((plugin) => plugin.slug === "wordpress-seo")) {
+      if (activeSlugs.has("wordpress-seo")) {
         this.detectedPlugin = "yoast";
         return;
       }
 
       // Check for RankMath
-      if (activePlugins.some((plugin) => plugin.slug === "seo-by-rank-math")) {
+      if (activeSlugs.has("seo-by-rank-math")) {
         this.detectedPlugin = "rankmath";
         return;
       }
 
       // Check for SEOPress
-      if (activePlugins.some((plugin) => plugin.slug === "wp-seopress")) {
+      if (activeSlugs.has("wp-seopress")) {
         this.detectedPlugin = "seopress";
         return;
       }

--- a/src/client/SEOWordPressClient.ts
+++ b/src/client/SEOWordPressClient.ts
@@ -29,11 +29,15 @@ import type { SEOMetadata, SchemaMarkup } from "@/types/seo.js";
  *
  * GET /wp/v2/plugins identifies a plugin by `plugin` — its file path relative to the
  * plugins directory with the .php extension stripped, e.g. "wordpress-seo/wp-seo". The
- * response carries no `slug` field; it stays optional here only so callers holding a
- * hand-built object still type-check.
+ * response carries no `slug` field at all.
+ *
+ * Both identifying fields are optional because this describes an external payload we do
+ * not control: `slug` so that a hand-built `{ slug, status }` object still type-checks,
+ * and `plugin` so a response missing it degrades to no match rather than a crash.
+ * pluginSlug() resolves whichever is present.
  */
 interface WordPressPlugin {
-  plugin: string;
+  plugin?: string;
   status: "active" | "inactive";
   slug?: string;
   name?: string;
@@ -187,9 +191,6 @@ export class SEOWordPressClient extends WordPressClient {
   }
 
   /**
-   * Detect active SEO plugins on the WordPress site
-   */
-  /**
    * Derives a plugin slug from a /wp/v2/plugins entry. The REST response has no `slug`
    * field, so the slug is the directory segment of `plugin`: "seo-by-rank-math/rank-math"
    * yields "seo-by-rank-math". Matching the whole segment rather than a prefix keeps
@@ -200,6 +201,9 @@ export class SEOWordPressClient extends WordPressClient {
     return plugin.slug ?? plugin.plugin?.split("/")[0] ?? "";
   }
 
+  /**
+   * Detect active SEO plugins on the WordPress site
+   */
   private async detectSEOPlugins(): Promise<void> {
     try {
       // Get list of installed plugins

--- a/tests/client/SEOWordPressClient.test.js
+++ b/tests/client/SEOWordPressClient.test.js
@@ -145,6 +145,74 @@ describe("SEOWordPressClient", () => {
     });
   });
 
+  // Regression tests for #235. The WordPress REST API GET /wp/v2/plugins does not
+  // return a `slug` field at all — it identifies a plugin by `plugin`, the plugin
+  // file path relative to the plugins directory without its .php extension
+  // (e.g. "seo-by-rank-math/rank-math"). The directory segment is the slug.
+  describe("Plugin Detection (actual /wp/v2/plugins response shape)", () => {
+    const restPlugin = (plugin, overrides = {}) => ({
+      plugin,
+      status: "active",
+      name: plugin,
+      textdomain: plugin.split("/")[0],
+      ...overrides,
+    });
+
+    it("should detect Yoast SEO from the plugin path", async () => {
+      mockWordPressClient.get.mockResolvedValueOnce([restPlugin("wordpress-seo/wp-seo")]);
+
+      await client.initializeSEO();
+
+      expect(client.detectedPlugin).toBe("yoast");
+    });
+
+    it("should detect RankMath from the plugin path", async () => {
+      mockWordPressClient.get.mockResolvedValueOnce([restPlugin("seo-by-rank-math/rank-math")]);
+
+      await client.initializeSEO();
+
+      expect(client.detectedPlugin).toBe("rankmath");
+    });
+
+    it("should detect SEOPress from the plugin path", async () => {
+      mockWordPressClient.get.mockResolvedValueOnce([restPlugin("wp-seopress/seopress")]);
+
+      await client.initializeSEO();
+
+      expect(client.detectedPlugin).toBe("seopress");
+    });
+
+    it("should detect RankMath when the PRO add-on is active alongside it", async () => {
+      mockWordPressClient.get.mockResolvedValueOnce([
+        restPlugin("seo-by-rank-math/rank-math"),
+        restPlugin("seo-by-rank-math-pro/rank-math-pro"),
+      ]);
+
+      await client.initializeSEO();
+
+      expect(client.detectedPlugin).toBe("rankmath");
+    });
+
+    it("should not match a plugin whose directory merely starts with a known slug", async () => {
+      mockWordPressClient.get.mockResolvedValueOnce([restPlugin("wordpress-seo-extra/plugin")]);
+
+      await client.initializeSEO();
+
+      expect(client.detectedPlugin).toBe("none");
+    });
+
+    it("should ignore inactive plugins given in REST shape", async () => {
+      mockWordPressClient.get.mockResolvedValueOnce([
+        restPlugin("wordpress-seo/wp-seo", { status: "inactive" }),
+        restPlugin("seo-by-rank-math/rank-math"),
+      ]);
+
+      await client.initializeSEO();
+
+      expect(client.detectedPlugin).toBe("rankmath");
+    });
+  });
+
   describe("SEO Metadata Extraction", () => {
     beforeEach(async () => {
       // Set up with Yoast detected


### PR DESCRIPTION
Fixes #235.

## Problem

`detectSEOPlugins()` compared `plugin.slug` against `"wordpress-seo"`, `"seo-by-rank-math"` and `"wp-seopress"`. `GET /wp/v2/plugins` returns **no `slug` field** — it identifies a plugin by `plugin`, the plugin file path relative to the plugins directory with `.php` stripped (e.g. `seo-by-rank-math/rank-math`).

Every comparison was therefore `undefined === string`. Detection silently fell through to `"none"` on every site, and all SEO tools quietly used the generic metadata path.

Two things hid this:

- The local `WordPressPlugin` interface declared `slug: string` as **required**, asserting a field the API never sends — so TypeScript could not flag it.
- The existing detection tests mocked that same fictional shape (`{ slug: "wordpress-seo", status: "active" }`), so they passed against the bug.

## Fix

Derive the slug from `plugin`: its directory segment is the slug (`seo-by-rank-math/rank-math` → `seo-by-rank-math`). Matching the whole segment, not a prefix, keeps `seo-by-rank-math-pro` from being mistaken for the base plugin — relevant since the reporter runs Rank Math and Rank Math PRO together.

The interface now mirrors the real response; `slug` stays optional so hand-built objects still type-check, which keeps the pre-existing tests meaningful rather than deleting them.

## Verification

- 6 new regression tests using the actual REST response shape, including the PRO-add-on case and a near-miss directory name.
- Confirmed red before the fix (5 failing), green after.
- Full suite: 2,494 tests pass. `typecheck`, `lint`, `format:check` clean.
- Grepped for other `/wp/v2/plugins` consumers — this is the only detection site.

## Not addressed here

The reporter's second observation is a genuinely separate defect: `wp_seo_bulk_update_metadata` reports `success: 1` while WordPress silently discards writes to `rank_math_*` meta keys that aren't registered with `show_in_rest`. That needs a read-back-after-write check and is left for its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Correct SEO plugin detection to derive exact plugin slugs from WordPress REST API paths.

Bug Fixes:
- Fix SEO plugin detection to identify active Yoast, Rank Math, and SEOPress plugins from the WordPress REST API plugin path.
- Prevent similarly named plugin directories and inactive plugins from being misidentified as supported SEO plugins.

Enhancements:
- Align the WordPress plugin response type with the REST API and support optional identifying fields.

Tests:
- Add regression coverage using the actual REST plugin response shape, including Rank Math PRO coexistence, near-miss names, and inactive plugins.