### PR TITLE
fix(ci): skip claude-review for bot-triggered PR pushes

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,8 +13,14 @@ on:
 jobs:
   claude-review:
     runs-on: ubuntu-latest
-    # OIDC tokens are unavailable for fork PRs (GitHub restriction); skip to avoid spurious failures
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # OIDC tokens are unavailable for fork PRs (GitHub restriction); skip to avoid spurious failures.
+    # Also skip when the triggering push's sender is a bot/app (e.g. GitHub Copilot's coding agent,
+    # login "Copilot" / https://github.com/apps/copilot-swe-agent): the action's OIDC-to-app-token
+    # exchange rejects bot actors with "User does not have write access on this repository" even on
+    # same-repo PRs, so the job fails before it can review anything.
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.sender.type != 'Bot'
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Problem

`anthropics/claude-code-action`'s OIDC-to-app-token exchange rejects bot/app actors with `401 Unauthorized - User does not have write access on this repository`, even on same-repo (non-fork) PRs. Confirmed on PR #238: a push from GitHub Copilot's coding agent (login `Copilot`, https://github.com/apps/copilot-swe-agent, id `198982749`) failed the `claude-review` job before it could review anything — despite the PR itself being authored by a human collaborator (`docdyhr`).

Verified via the Actions API on the two runs:

| Run | `actor.login` | `actor.type` | Result |
|---|---|---|---|
| PR #238 (Copilot push) | `Copilot` | `Bot` | fails: `User does not have write access` |
| PR #237 (human push) | `docdyhr` | `User` | passes |

## Fix

Extend the job's existing fork-check `if:` condition to also skip when `github.event.sender.type == 'Bot'`. Checking `sender.type` generically (rather than allowlisting the `Copilot` login specifically) covers any bot/app that pushes to a same-repo PR branch — Dependabot, Renovate, other coding agents — not just this one instance.

`claude-review` is not a required status check, so this only removes a false-red signal; it doesn't change what can merge.

## Verification

- `python3 -c "import yaml; yaml.safe_load(...)"` — YAML parses
- `actionlint .github/workflows/claude-code-review.yml` — clean
- Full test suite (2,438 tests), lint, typecheck — all clean (pre-commit/pre-push hooks passed)

## Summary by Sourcery

Skip Claude review for pull request pushes triggered by bots or apps that cannot complete the action's token exchange.

Bug Fixes:
- Prevent the Claude review job from producing false failures when pull request updates are pushed by bot or app actors.

CI:
- Update the Claude review workflow to skip bot-triggered pushes in addition to fork pull requests.